### PR TITLE
Web call resiliency improvements

### DIFF
--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -192,7 +192,7 @@ retry:
     const auto& cd = headers["Content-Disposition"];
 
     // attempt to get true filename
-    if (code == 200 && !cd.empty())
+    if (code == httplib::OK_200 && !cd.empty())
     {
         std::vector<std::string> arguments;
         char dl = ';';
@@ -241,9 +241,9 @@ retry:
         }
     }
     
-    if (code != 200)
+    if (code != httplib::OK_200)
     {
-        if (--retryCount > 0)
+        if (code != httplib::NotFound_404 && --retryCount > 0)
         {
             spdlog::debug("Web request failed (code {}), retrying {} more time(s)", code, retryCount);
 
@@ -290,9 +290,9 @@ retry:
 
     auto [code, body, _] = conn->get(updateRequestUrl);
 
-    if (code != 200)
+    if (code != httplib::OK_200)
     {
-        if (--retryCount > 0)
+        if (code != httplib::NotFound_404 && --retryCount > 0)
         {
             spdlog::debug("Web request failed (code {}), retrying {} more time(s)", code, retryCount);
 

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -243,9 +243,9 @@ retry:
     
     if (code != 200)
     {
-        if (retryCount-- > 0)
+        if (--retryCount > 0)
         {
-            spdlog::debug("Web request failed, retrying");
+            spdlog::debug("Web request failed (code {}), retrying {} more time(s)", code, retryCount);
 
             std::mt19937_64 eng{std::random_device{}()};
             std::uniform_int_distribution<> dist{1000, 5000};
@@ -292,9 +292,9 @@ retry:
 
     if (code != 200)
     {
-        if (retryCount-- > 0)
+        if (--retryCount > 0)
         {
-            spdlog::debug("Web request failed, retrying");
+            spdlog::debug("Web request failed (code {}), retrying {} more time(s)", code, retryCount);
 
             std::mt19937_64 eng{std::random_device{}()};
             std::uniform_int_distribution<> dist{1000, 5000};

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -254,7 +254,9 @@ retry:
             goto retry;
         }
 
-        spdlog::error("GET request failed with code {}", code);
+        auto errorMessage = magic_enum::enum_name<CURLcode>(static_cast<CURLcode>(code));
+        errorMessage = errorMessage.empty() ? httplib::status_message(code) : errorMessage;
+        spdlog::error("GET request failed with code {}, message {}", code, errorMessage);
 
         // clean up local file since we re-download it when the user decides to retry
         if (DeleteFileA(release.localTempFilePath.string().c_str()) == 0)
@@ -302,10 +304,10 @@ retry:
 
             goto retry;
         }
-
-        spdlog::error("GET request failed with code {}", code);
+                
         auto errorMessage = magic_enum::enum_name<CURLcode>(static_cast<CURLcode>(code));
         errorMessage = errorMessage.empty() ? httplib::status_message(code) : errorMessage;
+        spdlog::error("GET request failed with code {}, message {}", code, errorMessage);
         return std::make_tuple(false, std::format("HTTP error {}", errorMessage));
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,7 +495,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                 if (instStep == DownloadAndInstallStep::Downloading && hasFinished)
                 {
                     spdlog::debug("Download finished with status code {}", statusCode);
-                    instStep = statusCode == 200
+                    instStep = statusCode == httplib::OK_200
                                    ? DownloadAndInstallStep::DownloadSucceeded
                                    : DownloadAndInstallStep::DownloadFailed;
                 }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -5,6 +5,7 @@
 #include <SFML/OpenGL.hpp>
 #include <restclient-cpp/restclient.h>
 #include <restclient-cpp/connection.h>
+#include <httplib.h>
 
 
 // Fonts shared throughout app
@@ -151,7 +152,7 @@ struct changelog : public imgui_md
 
             const RestClient::Response response = conn->get(url);
 
-            if (response.code != 200)
+            if (response.code != httplib::OK_200)
                 return nullptr;
 
             auto res = std::make_shared<sf::Texture>();

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -26,6 +26,7 @@ struct changelog : public imgui_md
     std::map<std::string, std::shared_ptr<sf::Texture>> _images;
     std::string m_img_href;
     std::regex m_regex_link_target;
+    std::map<std::string, std::optional<std::shared_future<std::shared_ptr<sf::Texture>>>> imageDownloadTasks;
 
     explicit changelog(const std::map<std::string, std::shared_ptr<sf::Texture>>& images) : _images(images)
     {
@@ -137,6 +138,23 @@ struct changelog : public imgui_md
         return textureID;
     }
 
+    std::shared_ptr<sf::Texture> DownloadImageTexture(const std::string& url) const
+    {
+        const auto conn = new RestClient::Connection("");
+        conn->FollowRedirects(true, 5);
+        conn->SetTimeout(5);
+
+        const RestClient::Response response = conn->get(url);
+
+        if (response.code != httplib::OK_200)
+            return nullptr;
+
+        auto res = std::make_shared<sf::Texture>();
+        res->loadFromMemory(response.body.data(), response.body.length());
+
+        return res;
+    }
+
     /**
      * \brief Downloads a remote image resource and caches it in memory.
      * \param url The href of the image.
@@ -147,19 +165,48 @@ struct changelog : public imgui_md
         // this gets called on every frame so we only download it once and cache it
         if (!_images.contains(url))
         {
-            const auto conn = new RestClient::Connection("");
-            conn->FollowRedirects(true, 5);
+            // no download task is assigned to the given url, initiate
+            if (!imageDownloadTasks.contains(url) || !imageDownloadTasks[url].has_value())
+            {
+                const std::optional<std::shared_future<std::shared_ptr<sf::Texture>>> downloadTask = std::async(
+                    std::launch::async,
+                    &changelog::DownloadImageTexture,
+                    this,
+                    url
+                );
+                imageDownloadTasks[url] = downloadTask;
+            }
+            // task is running or finished
+            else if (imageDownloadTasks[url].has_value())
+            {
+                const auto task = imageDownloadTasks[url];
+                const std::future_status status = (*task).wait_for(std::chrono::milliseconds(1));
 
-            const RestClient::Response response = conn->get(url);
+                const bool isDownloading = status == std::future_status::timeout;
+                const bool hasFinished = status == std::future_status::ready;
 
-            if (response.code != httplib::OK_200)
-                return nullptr;
+                // no texture to report yet
+                if (isDownloading)
+                    return nullptr;
 
-            auto res = std::make_shared<sf::Texture>();
-            res->loadFromMemory(response.body.data(), response.body.length());
+                // task done (succeeded or failed)
+                if (hasFinished)
+                {
+                    auto res = (*task).get();
 
-            _images.emplace(url, res);
-            return res;
+                    // got our image, cache and return
+                    if (res != nullptr)
+                    {
+                        _images.emplace(url, res);
+                        return res;
+                    }
+
+                    // retry on next frame
+                    imageDownloadTasks[url].reset();
+                }
+            }
+
+            return nullptr;
         }
 
         return _images[url];


### PR DESCRIPTION
Fixes #47 

- Added retry logic on all web calls
- Made Markdown image fetching asynchronous to not block UI thread on bad network performance