### PR TITLE
Log errors if parsing release versions fails

### DIFF
--- a/src/UpdateRelease.cpp
+++ b/src/UpdateRelease.cpp
@@ -50,4 +50,6 @@ std::optional<semver::version> models::UpdateRelease::GetDetectionSemVersion() c
 
         return std::nullopt;
     }
+
+    return std::nullopt;
 }

--- a/src/UpdateRelease.cpp
+++ b/src/UpdateRelease.cpp
@@ -13,10 +13,15 @@ semver::version models::UpdateRelease::GetSemVersion() const
 
         return semver::version::parse(value);
     }
+    catch (const std::exception& e)
+    {
+        spdlog::debug("Error parsing update version `{}`: {}", version, e.what());
+    }
     catch (...)
     {
-        return semver::version{0, 0, 0};
+        spdlog::debug("Unknown exception parsing update version `{}`", version);
     }
+    return semver::version{0, 0, 0};
 }
 
 std::optional<semver::version> models::UpdateRelease::GetDetectionSemVersion() const
@@ -35,8 +40,14 @@ std::optional<semver::version> models::UpdateRelease::GetDetectionSemVersion() c
 
         return semver::version::parse(value);
     }
+    catch (const std::exception& e)
+    {
+        spdlog::debug("Error parsing update version `{}`: {}", version, e.what());
+    }
     catch (...)
     {
+        spdlog::debug("Unknown exception parsing update detection version `{}`", version);
+
         return std::nullopt;
     }
 }


### PR DESCRIPTION
In particular, it doesn't like the `0` in `2024.07.13` as a version number