### PR TITLE
Add support for zip files updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ This tool benefits from these awesome projects ❤ (appearance in no special ord
 - [Simple C++ ini parser](https://github.com/mcmtroffaes/inipp)
 - [MimeTypes](https://github.com/lasselukkari/MimeTypes)
 - [A C++ header-only HTTP/HTTPS server and client library](https://github.com/yhirose/cpp-httplib)
+- [A C library for reading, creating, and modifying zip archives](https://github.com/nih-at/libzip)
 
 ### Literature & references
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 #- cmd: vcpkg integrate install
 #- cmd: vcpkg update
 # manifest mode takes forever to build each commit so use global copy instead
-- cmd: (for /l %i in () do (vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static) && exit /b 0 || (timeout /t 5 >nul & echo Retrying...))
+- cmd: vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static
 - ps: Setup-VS2022 $env:PLATFORM
 before_build:
 - cmd: nuget restore vīcĭus.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 #- cmd: vcpkg integrate install
 #- cmd: vcpkg update
 # manifest mode takes forever to build each commit so use global copy instead
-- cmd: vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static
+- cmd: (for /l %i in () do (vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static) && exit /b 0 || (timeout /t 5 >nul & echo Retrying...))
 - ps: Setup-VS2022 $env:PLATFORM
 before_build:
 - cmd: nuget restore vīcĭus.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ install:
 - cmd: git submodule -q update --init
 #- cmd: vcpkg integrate install
 #- cmd: vcpkg update
+# workaround for "CMake Error: Not a file: C:\tools\vcpkg\buildtrees\0.vcpkg_dep_info.cmake"
+- ps: Start-Sleep -Seconds (Get-Random -Minimum 1 -Maximum 6)
 # manifest mode takes forever to build each commit so use global copy instead
 - cmd: vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static
 - ps: Setup-VS2022 $env:PLATFORM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 #- cmd: vcpkg integrate install
 #- cmd: vcpkg update
 # manifest mode takes forever to build each commit so use global copy instead
-- cmd: vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static
+- cmd: vcpkg install argh:%PLATFORM%-windows-static sfml:%PLATFORM%-windows-static imgui[freetype,wchar32]:%PLATFORM%-windows-static imgui-sfml:%PLATFORM%-windows-static restclient-cpp:%PLATFORM%-windows-static nlohmann-json:%PLATFORM%-windows-static magic-enum:%PLATFORM%-windows-static z4kn4fein-semver:%PLATFORM%-windows-static winreg:%PLATFORM%-windows-static hash-library:%PLATFORM%-windows-static spdlog:%PLATFORM%-windows-static scope-guard:%PLATFORM%-windows-static curlpp:%PLATFORM%-windows-static inja:%PLATFORM%-windows-static cpp-httplib:%PLATFORM%-windows-static libzip:%PLATFORM%-windows-static
 - ps: Setup-VS2022 $env:PLATFORM
 before_build:
 - cmd: nuget restore vīcĭus.sln

--- a/examples/server/server.csproj
+++ b/examples/server/server.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FastEndpoints" Version="5.27.0" />
-        <PackageReference Include="FastEndpoints.Swagger" Version="5.27.0"/>
+        <PackageReference Include="FastEndpoints" Version="5.28.0" />
+        <PackageReference Include="FastEndpoints.Swagger" Version="5.28.0" />
         <PackageReference Include="Nefarius.Utilities.AspNetCore" Version="2.3.0"/>
-        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.1.1" />
+        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.2.0" />
         <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.0.2" />
         <PackageReference Include="Octokit" Version="13.0.1" />
     </ItemGroup>

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -217,6 +217,11 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                 const auto sourceRoot = std::filesystem::canonical(*extractedPath);
                 const auto destRoot = std::filesystem::canonical(this->GetAppPath().parent_path());
 
+                const auto defaultDisposition =
+                    release.zipExtractDefaultFileDisposition.value_or(ZipExtractFileDisposition::CreateOrReplace);
+                const auto dispositionOverrides = release.zipExtractFileDispositionOverrides.value_or(
+                    std::unordered_map<std::string, ZipExtractFileDisposition>{});
+
                 // Walk 1/2: create or update only, no deletions
                 for (const auto& it : std::filesystem::recursive_directory_iterator(sourceRoot))
                 {
@@ -225,9 +230,9 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                     const auto dest = destRoot / relative;
 
                     const auto relativeUTF8 = ToUTF8(relative.wstring());
-                    const auto disposition = release.zipExtractFileDispositionOverrides.contains(relativeUTF8)
-                                                 ? release.zipExtractFileDispositionOverrides.at(relativeUTF8)
-                                                 : release.zipExtractDefaultFileDisposition;
+                    const auto disposition = dispositionOverrides.contains(relativeUTF8)
+                                                 ? dispositionOverrides.at(relativeUTF8)
+                                                 : defaultDisposition;
 
                     if (it.is_directory())
                     {

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -265,7 +265,7 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                     std::filesystem::last_write_time(dest, std::filesystem::last_write_time(source));
                 }
                 // Walk 2/2: deletions
-                for (const auto& [ relative, disposition ] : release.zipExtractFileDispositionOverrides)
+                for (const auto& [ relative, disposition ] : dispositionOverrides)
                 {
                     if (disposition != Disposition::DeleteIfPresent)
                     {

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -217,16 +217,6 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                 const auto sourceRoot = std::filesystem::canonical(*extractedPath);
                 const auto destRoot = std::filesystem::canonical(this->GetAppPath().parent_path());
 
-                const auto GetDisposition = [ &release ](const std::filesystem::path& relative)
-                {
-                    const auto utf8 = ToUTF8(relative.wstring());
-                    if (release.zipExtractFileDispositionOverrides.contains(utf8))
-                    {
-                        return release.zipExtractFileDispositionOverrides.at(utf8);
-                    }
-                    return release.zipExtractDefaultFileDisposition;
-                };
-
                 // Walk 1/2: create or update only, no deletions
                 for (const auto& it : std::filesystem::recursive_directory_iterator(sourceRoot))
                 {

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -274,6 +274,10 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                     {
                         continue;
                     }
+                    if (!std::filesystem::canonical(dest).wstring().starts_with(destRoot.wstring()))
+                    {
+                        spdlog::warn("Cowardly refusing to delete files outside of the installation directory");
+                    }
                     std::filesystem::remove_all(destRoot / relative);
                 }
             }

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -23,7 +23,7 @@ namespace
         // - vicius currently targets Windows 7+, and ICU is only included with some versions of Windows 10
         // - adding it to vcpkg pulls in a *huge* amount of the msys ecosystem as dependencies
         const auto utf8ByteCount =
-          WideCharToMultiByte(CP_UTF8, 0, view.data(), static_cast<int>(view.size()), nullptr, 0, nullptr, nullptr);
+            WideCharToMultiByte(CP_UTF8, 0, view.data(), static_cast<int>(view.size()), nullptr, 0, nullptr, nullptr);
         if (!utf8ByteCount)
         {
             return {};
@@ -143,7 +143,7 @@ std::optional<std::filesystem::path> models::InstanceConfig::ExtractReleaseZip(z
 
                 std::ofstream f(outPath, std::ios::binary);
 
-                constexpr std::size_t chunkSize = 4 * 1024;  // 4KB
+                constexpr std::size_t chunkSize = 4 * 1024; // 4KB
                 char buffer[ chunkSize ];
 
                 decltype(stat.size) bytesRead = 0;
@@ -221,15 +221,16 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                 };
 
                 // Walk 1/2: create or update only, no deletions
-                for (const auto& it : std::filesystem::recursive_directory_iterator(sourceRoot)) {
+                for (const auto& it : std::filesystem::recursive_directory_iterator(sourceRoot))
+                {
                     const auto relative = std::filesystem::relative(it.path(), sourceRoot);
                     const auto source = sourceRoot / relative;
                     const auto dest = destRoot / relative;
 
                     const auto relativeUTF8 = ToUTF8(relative.wstring());
                     const auto disposition = release.zipExtractFileDispositionOverrides.contains(relativeUTF8)
-                                               ? release.zipExtractFileDispositionOverrides.at(relativeUTF8)
-                                               : release.zipExtractDefaultFileDisposition;
+                                                 ? release.zipExtractFileDispositionOverrides.at(relativeUTF8)
+                                                 : release.zipExtractDefaultFileDisposition;
 
                     if (it.is_directory())
                     {
@@ -260,7 +261,6 @@ std::tuple<bool, DWORD, DWORD> models::InstanceConfig::ExecuteSetup()
                             break;
                     }
                     std::filesystem::last_write_time(dest, std::filesystem::last_write_time(source));
-
                 }
                 // Walk 2/2: deletions
                 for (const auto& [ relative, disposition ] : release.zipExtractFileDispositionOverrides)

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -8,6 +8,9 @@
 
 using json = nlohmann::json;
 
+struct zip;
+typedef struct zip zip_t;
+
 namespace models
 {
     /**
@@ -195,6 +198,15 @@ namespace models
          * \param progressFn The download progress callback.
          */
         bool DownloadReleaseAsync(int releaseIndex, curl_progress_callback progressFn);
+
+
+        /**
+        * \brief Extract the zip file containing updated executables.
+        *
+        * \param zip the zip file; the caller retains ownership.
+        * \return Path of folder containing extracted zip file contents on success, empty otherwise.
+        */
+        std::optional<std::filesystem::path> ExtractReleaseZip(zip_t* zip);
 
         /**
          * \brief Checks the current download status.

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -34,6 +34,21 @@ namespace models
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ChecksumParameters, checksum, checksumAlg)
 
     /**
+     * \brief How to treat files when installing a .zip file
+     */
+    enum class ZipExtractFileDisposition
+    {
+        CreateIfAbsent,
+        CreateOrReplace,
+        DeleteIfPresent,
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(ZipExtractFileDisposition,
+                                 {{ZipExtractFileDisposition::CreateIfAbsent, "CreateIfAbsent"},
+                                  {ZipExtractFileDisposition::CreateOrReplace, "CreateOrReplace"},
+                                  {ZipExtractFileDisposition::DeleteIfPresent, "DeleteIfPresent"}});
+
+    /**
      * \brief Represents an update release.
      */
     class UpdateRelease
@@ -65,9 +80,15 @@ namespace models
         std::optional<size_t> detectionSize;
         /** The version to use in product detection */
         std::optional<std::string> detectionVersion;
+        /** How to handle files in a zip update, unless overriden */
+        ZipExtractFileDisposition zipExtractDefaultFileDisposition{ZipExtractFileDisposition::CreateOrReplace};
+        /** Override the behavior for specific files in a zip update */
+        std::unordered_map<std::string, ZipExtractFileDisposition> zipExtractFileDispositionOverrides;
 
         /** Full pathname of the local temporary file */
         std::filesystem::path localTempFilePath{};
+
+
 
         /**
          * \brief Converts the version string to a SemVer type.
@@ -95,5 +116,7 @@ namespace models
                                                     disabled,
                                                     detectionChecksum,
                                                     detectionSize,
-                                                    detectionVersion)
+                                                    detectionVersion,
+                                                    zipExtractDefaultFileDisposition,
+                                                    zipExtractFileDispositionOverrides)
 }

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -84,9 +84,9 @@ namespace models
         /** The version to use in product detection */
         std::optional<std::string> detectionVersion;
         /** How to handle files in a zip update, unless overriden */
-        ZipExtractFileDisposition zipExtractDefaultFileDisposition{ZipExtractFileDisposition::CreateOrReplace};
+        std::optional<ZipExtractFileDisposition> zipExtractDefaultFileDisposition;
         /** Override the behavior for specific files in a zip update */
-        std::unordered_map<std::string, ZipExtractFileDisposition> zipExtractFileDispositionOverrides;
+        std::optional<std::unordered_map<std::string, ZipExtractFileDisposition>> zipExtractFileDispositionOverrides;
 
         /** Full pathname of the local temporary file */
         std::filesystem::path localTempFilePath{};

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -44,9 +44,12 @@ namespace models
     };
 
     NLOHMANN_JSON_SERIALIZE_ENUM(ZipExtractFileDisposition,
-                                 {{ZipExtractFileDisposition::CreateIfAbsent, "CreateIfAbsent"},
-                                  {ZipExtractFileDisposition::CreateOrReplace, "CreateOrReplace"},
-                                  {ZipExtractFileDisposition::DeleteIfPresent, "DeleteIfPresent"}});
+                                 {{ZipExtractFileDisposition::CreateIfAbsent,
+                                 magic_enum::enum_name(ZipExtractFileDisposition::CreateIfAbsent)},
+                                 {ZipExtractFileDisposition::CreateOrReplace,
+                                 magic_enum::enum_name(ZipExtractFileDisposition::CreateOrReplace)},
+                                 {ZipExtractFileDisposition::DeleteIfPresent,
+                                 magic_enum::enum_name(ZipExtractFileDisposition::DeleteIfPresent)}});
 
     /**
      * \brief Represents an update release.
@@ -87,7 +90,6 @@ namespace models
 
         /** Full pathname of the local temporary file */
         std::filesystem::path localTempFilePath{};
-
 
 
         /**

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -24,6 +24,7 @@
     "scope-guard",
     "curlpp",
     "inja",
-    "cpp-httplib"
+    "cpp-httplib",
+    "libzip"
   ]
 }


### PR DESCRIPTION
Tested by adding executable and following config files to https://github.com/fredemmott/OpenXR-API-Layers-GUI/releases/tag/v2024.03.13

## Local config

```json
{
	"instance": {
		"serverUrlTemplate": "http://[::1]:8080/{}.json",
		"filenameRegex": "(\\w+)_([a-zA-Z0-9-]+)_Updater"
	},
	"shared": {
		"detectionMethod": "CustomExpression",
		"detection": {
			"input": "{{true}}"
		}
	}
}
```

## Remote config

```json
{
	"shared": {
		"productName": "OpenXR API Layers GUI",
		"windowTitle": "OpenXR API Layers GUI Updater"
	},
	"releases": [
		{
			"name": "OpenXR API Layers GUI Update",
			"version": "2024.7.18",
			"summary": "Blah blah blah",
			"publishedAt": "2024-07-18T13:15:35Z",
			"downloadUrl": "https://github.com/fredemmott/OpenXR-API-Layers-GUI/releases/download/v2024.07.18/OpenXR-API-Layers-GUI-v2024.07.18.154.zip",
			"zipExtractFileDispositionOverrides": {
				"!-- Old executables that have been replaced by OpenXR-API-Layers-GUI.exe": "DeleteIfPresent",
				"OpenXR-API-Layers-Win32-HKCU.exe": "DeleteIfPresent",
				"OpenXR-API-Layers-Win32-HKLM.exe": "DeleteIfPresent",
				"OpenXR-API-Layers-Win64-HKCU.exe": "DeleteIfPresent",
				"OpenXR-API-Layers-Win64-HKLM.exe": "DeleteIfPresent",
				"!-- No longer relevant due to the above": "DeleteIfPresent",
				"README-Windows.txt": "DeleteIfPresent",
				"!-- metadata that is now embedded in the executables": "DeleteIfPresent",
				"version.txt": "DeleteIfPresent",
				"LICENSE.txt": "DeleteIfPresent"
			}
		}
	]
}
```