### PR TITLE
Use git instead of 'builtin' for base vcpkg repository

### DIFF
--- a/src/vcpkg-configuration.json
+++ b/src/vcpkg-configuration.json
@@ -8,7 +8,8 @@
     }
   ],
   "default-registry": {
-    "kind": "builtin",
-    "baseline": "2024.07.12"
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "1de2026f28ead93ff1773e6e680387643e914ea1"
   }
 }


### PR DESCRIPTION
Using builtin leads to misleading error messages, unless my user installation of vcpkg happens to be at the exact correct tag; fetching isn't enough, I need to actually have that version checked out.

As well as the misleading error messages, depending on my per-user versions seems underirable, as it conflicts with the goals of manifest mode.

This also switches to a full commit hash, as that is required for `git` registries; it seems like an oversight/accident that it isn't for `builtin`. In general, tags can be moved, so aren't suitable when supply-chain-attacks are plausible