### PR TITLE
Add --terminate-process-before-update=HANDLE option

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -4,51 +4,53 @@
 // Constants
 //
 
-#define NV_ADS_UPDATER_NAME        ":updater.dll"
-#define NV_CLI_INSTALL             "--install"
-#define NV_CLI_UNINSTALL           "--uninstall"
+#define NV_ADS_UPDATER_NAME                          ":updater.dll"
+#define NV_CLI_INSTALL                               "--install"
+#define NV_CLI_UNINSTALL                             "--uninstall"
 // internal
-#define NV_CLI_AUTOSTART           "--autostart"
+#define NV_CLI_AUTOSTART                             "--autostart"
 // internal
-#define NV_CLI_BACKGROUND          "--background"
-#define NV_CLI_PARAM_LOG_LEVEL     "--log-level"
-#define NV_CLI_SKIP_SELF_UPDATE    "--skip-self-update"
-#define NV_CLI_SILENT              "--silent"
-#define NV_CLI_SILENT_UPDATE       "--silent-update"
-#define NV_CLI_IGNORE_BUSY_STATE   "--ignore-busy-state"
-#define NV_CLI_PARAM_LOG_TO_FILE   "--log-to-file"
-#define NV_CLI_PARAM_SERVER_URL    "--server-url"
-#define NV_CLI_NO_SCHEDULED_TASK   "--no-scheduled-task"
-#define NV_CLI_NO_AUTOSTART        "--no-autostart"
-#define NV_CLI_PARAM_CHANNEL       "--channel"
-#define NV_CLI_PARAM_ADD_HEADER    "--add-header"
-#define NV_CLI_PARAM_OVERRIDE_OK   "--override-success-code"
-#define NV_CLI_IGNORE_POSTPONE     "--ignore-postpone"
-#define NV_CLI_PURGE_POSTPONE      "--purge-postpone"
+#define NV_CLI_BACKGROUND                            "--background"
+#define NV_CLI_PARAM_LOG_LEVEL                       "--log-level"
+#define NV_CLI_SKIP_SELF_UPDATE                      "--skip-self-update"
+#define NV_CLI_SILENT                                "--silent"
+#define NV_CLI_SILENT_UPDATE                         "--silent-update"
+#define NV_CLI_IGNORE_BUSY_STATE                     "--ignore-busy-state"
+#define NV_CLI_PARAM_LOG_TO_FILE                     "--log-to-file"
+#define NV_CLI_PARAM_SERVER_URL                      "--server-url"
+#define NV_CLI_NO_SCHEDULED_TASK                     "--no-scheduled-task"
+#define NV_CLI_NO_AUTOSTART                          "--no-autostart"
+#define NV_CLI_PARAM_CHANNEL                         "--channel"
+#define NV_CLI_PARAM_ADD_HEADER                      "--add-header"
+#define NV_CLI_PARAM_OVERRIDE_OK                     "--override-success-code"
+#define NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE "--terminate-process-before-update"
+#define NV_CLI_IGNORE_POSTPONE                       "--ignore-postpone"
+#define NV_CLI_PURGE_POSTPONE                        "--purge-postpone"
 // internal
-#define NV_CLI_TEMPORARY           "--temporary"
+#define NV_CLI_TEMPORARY                             "--temporary"
 
 //
 // App error exit codes
 //
 
-#define NV_E_CLI_PARSING           100
-#define NV_E_AUTOSTART             101
-#define NV_E_SCHEDULED_TASK        102
-#define NV_E_EXTRACT_SELF_UPDATE   103
-#define NV_E_SERVER_RESPONSE       104
-#define NV_E_PRODUCT_DETECTION     105
-#define NV_E_BUSY                  106
-#define NV_E_DOWNLOAD_FAILED       107
-#define NV_E_SETUP_LAUNCH_FAILED   108
-#define NV_E_SETUP_FAILED          109
-#define NV_E_POSTPONE_PURGE_FAILED 110
+#define NV_E_CLI_PARSING                             100
+#define NV_E_AUTOSTART                               101
+#define NV_E_SCHEDULED_TASK                          102
+#define NV_E_EXTRACT_SELF_UPDATE                     103
+#define NV_E_SERVER_RESPONSE                         104
+#define NV_E_PRODUCT_DETECTION                       105
+#define NV_E_BUSY                                    106
+#define NV_E_DOWNLOAD_FAILED                         107
+#define NV_E_SETUP_LAUNCH_FAILED                     108
+#define NV_E_SETUP_FAILED                            109
+#define NV_E_POSTPONE_PURGE_FAILED                   110
+#define NV_E_TERMINATE_PROCESS_BEFORE_UPDATE_FAILED  111
 
-#define NV_S_INSTALL               200
-#define NV_S_SELF_UPDATER          201
-#define NV_S_UP_TO_DATE            202
-#define NV_S_UPDATE_FINISHED       203
-#define NV_S_USER_POSTPONED        204
-#define NV_S_POSTPONE_PERIOD       205
-#define NV_S_POSTPONE_PURGE        206
-#define NV_S_LAUNCHED_TEMPORARY    207
+#define NV_S_INSTALL                                 200
+#define NV_S_SELF_UPDATER                            201
+#define NV_S_UP_TO_DATE                              202
+#define NV_S_UPDATE_FINISHED                         203
+#define NV_S_USER_POSTPONED                          204
+#define NV_S_POSTPONE_PERIOD                         205
+#define NV_S_POSTPONE_PURGE                          206
+#define NV_S_LAUNCHED_TEMPORARY                      207

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -76,16 +76,9 @@ bool models::InstanceConfig::RunSelfUpdater() const
 
         std::stringstream argsStream;
         // build CLI args
-        argsStream << "rundll32 \"" << ads << "\",PerformUpdate"
-                   << " --silent"
-                   << " --log-level " << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId()
-                   << " --path \"" << appPath.string() << "\""
-                   << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
-        if (terminateProcessBeforeUpdate.has_value())
-        {
-            argsStream << NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE << " "
-                       << reinterpret_cast<const uintptr_t>(terminateProcessBeforeUpdate.value());
-        }
+        argsStream << "rundll32 \"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
+                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
+                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 
@@ -118,16 +111,9 @@ bool models::InstanceConfig::RunSelfUpdater() const
 
         std::stringstream argsStream;
         // build CLI args
-        argsStream << "\"" << ads << "\",PerformUpdate"
-                   << " --silent"
-                   << " --log-level " << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId()
-                   << " --path \"" << appPath.string() << "\""
-                   << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
-        if (terminateProcessBeforeUpdate.has_value())
-        {
-            argsStream << NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE << " "
-                       << reinterpret_cast<const uintptr_t>(terminateProcessBeforeUpdate.value());
-        }
+        argsStream << "\"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
+                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
+                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -76,9 +76,16 @@ bool models::InstanceConfig::RunSelfUpdater() const
 
         std::stringstream argsStream;
         // build CLI args
-        argsStream << "rundll32 \"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
-                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
-                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        argsStream << "rundll32 \"" << ads << "\",PerformUpdate"
+                   << " --silent"
+                   << " --log-level " << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId()
+                   << " --path \"" << appPath.string() << "\""
+                   << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        if (terminateProcessBeforeUpdate.has_value())
+        {
+            argsStream << NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE << " "
+                       << reinterpret_cast<const uintptr_t>(terminateProcessBeforeUpdate.value());
+        }
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 
@@ -111,9 +118,16 @@ bool models::InstanceConfig::RunSelfUpdater() const
 
         std::stringstream argsStream;
         // build CLI args
-        argsStream << "\"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
-                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
-                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        argsStream << "\"" << ads << "\",PerformUpdate"
+                   << " --silent"
+                   << " --log-level " << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId()
+                   << " --path \"" << appPath.string() << "\""
+                   << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        if (terminateProcessBeforeUpdate.has_value())
+        {
+            argsStream << NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE << " "
+                       << reinterpret_cast<const uintptr_t>(terminateProcessBeforeUpdate.value());
+        }
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -126,10 +126,12 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
               "Pseudo-handle (e.g. from GetCurrentProcess()) passed to {}; use DuplicateHandle() with bInheritHandle set",
               NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE);
         }
-        else if (!GetCurrentProcessId())
+        else if (!GetProcessId(appHandle))
         {
             spdlog::error("Value passed to {} was not a valid HANDLE; use DuplicateHandle() with bInheritHandle set. If you "
-                          "passed a PID, use OpenProcess()");
+                          "passed a PID, use OpenProcess(). Error: {:#010x}",
+                          NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE,
+                          static_cast<uint32_t>(GetLastError()));
         }
         else
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     argh::parser cmdl;
 
     cmdl.add_params({NV_CLI_PARAM_LOG_LEVEL, NV_CLI_PARAM_LOG_TO_FILE, NV_CLI_PARAM_SERVER_URL, NV_CLI_PARAM_CHANNEL,
-                     NV_CLI_PARAM_ADD_HEADER, NV_CLI_PARAM_OVERRIDE_OK});
+                     NV_CLI_PARAM_ADD_HEADER, NV_CLI_PARAM_OVERRIDE_OK, NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE});
 
     if (!util::ParseCommandLineArguments(cmdl))
     {
@@ -608,18 +608,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                     break;
                     case DownloadAndInstallStep::InstallFailed:
 
-                        std::call_once(
-                          errorUrlTriggered,
-                          [ &cfg ]()
-                          {
-                              if (!cfg.GetInstallErrorUrl().has_value())
-                              {
-                                  return;
-                              }
+                        std::call_once(errorUrlTriggered,
+                                       [ &cfg ]()
+                                       {
+                                           if (!cfg.GetInstallErrorUrl().has_value())
+                                           {
+                                               return;
+                                           }
 
-                              ShellExecuteA(
-                                nullptr, "open", cfg.GetInstallErrorUrl().value().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-                          });
+                                           ShellExecuteA(nullptr, "open", cfg.GetInstallErrorUrl().value().c_str(), nullptr,
+                                                         nullptr, SW_SHOWNORMAL);
+                                       });
 
                         if (GetLastError() == ERROR_SUCCESS)
                         {

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -57,6 +57,8 @@ namespace models
         std::string updateRequestUrl;
         /** Full pathname of the updater parent process file, if any */
         std::optional<std::filesystem::path> parentAppPath;
+        /** Process to terminate before update */
+        std::optional<HANDLE> terminateProcessBeforeUpdate;
 
         /** The local and remote shared configuration */
         MergedConfig merged;


### PR DESCRIPTION
Needed for zip updaters if launched by the thing they're updating.

Tested with https://gist.github.com/fredemmott/4651df860b0ae0cc062020cdd503e5cf , which is a more 'interesting' test than I expected: the app runs elevated, but it de-elevates the updater. Sharing the process handle still works fine after jumping through a few hoops.

resharper does a lot of formatting changes here; best reviewed with whitespace ignored. IIRC you prefer to run resharper yourself anyway when merging?
