### PR TITLE
Add --local-version and --force-local-version flags

### DIFF
--- a/examples.sln.DotSettings
+++ b/examples.sln.DotSettings
@@ -3,5 +3,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=exebasicui/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FILTERNOTFOUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fredemmott/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nefarius/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=norestart/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vicius/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/examples/server/Endpoints/FixedVersionExample.cs
+++ b/examples/server/Endpoints/FixedVersionExample.cs
@@ -1,0 +1,76 @@
+﻿using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints;
+
+/// <summary>
+///     Demos a fixed version configuration.
+/// </summary>
+internal sealed class FixedVersionExampleEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/contoso/FixedVersion/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("Examples"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = ".NET Runtime",
+                WindowTitle = ".NET Runtime Updater",
+                Detection = new FixedVersionConfig()
+                {
+                    Version = "999.0.0",
+                }
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = ".NET Runtime Demo Update",
+                    PublishedAt = DateTimeOffset.UtcNow.AddDays(-3),
+                    Version = System.Version.Parse("9.0.14"),
+                    // Markdown support in summary (changelog, description)
+                    Summary = """
+                              ## Features
+                                * Awesome new thing
+                                * Also this
+                                * And that
+                                
+                              ## Bugfixes
+                                * Removed bug I put there
+                                * Whoops, that wasn't supposed to happen
+                                
+                              ## Nonsense
+                                * Need to see
+                                * What happens...
+                                * If we need scroll bars
+                                * Vertically
+                                * [Links are also supported!](https://example.org)
+                              """,
+                    // pulling bigger (~50MB) .NET runtime setup as an example to demo progress bar
+                    DownloadUrl =
+                        "https://download.visualstudio.microsoft.com/download/pr/f9ea536d-8e1f-4247-88b8-e79e33fa0873/c06e39f73a3bb1ec8833bb1cde98fce3/windowsdesktop-runtime-7.0.12-win-x64.exe",
+                    LaunchArguments = "/norestart",
+                    ExitCode = new ExitCodeCheck
+                    {
+                        SuccessCodes =
+                        {
+                            0, // regular success
+                            3010 // success, but reboot required
+                            // 1602 // failure (user cancelled) - you normally wouldn't want that as a success code, just an example
+                        }
+                    }
+                }
+            }
+        };
+
+        await SendOkAsync(response, ct);
+    }
+}

--- a/examples/server/Endpoints/RootEndpoint.cs
+++ b/examples/server/Endpoints/RootEndpoint.cs
@@ -2,7 +2,7 @@
 
 namespace Nefarius.Vicius.Example.Server.Endpoints;
 
-internal sealed class RootEndpoint : EndpointWithoutRequest
+internal sealed class RootEndpoint(IWebHostEnvironment environment) : EndpointWithoutRequest
 {
     public override void Configure()
     {
@@ -13,6 +13,8 @@ internal sealed class RootEndpoint : EndpointWithoutRequest
 
     public override Task HandleAsync(CancellationToken ct)
     {
-        return SendRedirectAsync("https://docs.nefarius.at/projects/Vicius/", allowRemoteRedirects: true);
+        return environment.IsDevelopment()
+            ? SendNotFoundAsync(ct)
+            : SendRedirectAsync("https://docs.nefarius.at/projects/Vicius/", allowRemoteRedirects: true);
     }
 }

--- a/examples/server/server.csproj
+++ b/examples/server/server.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="FastEndpoints" Version="5.28.0" />
         <PackageReference Include="FastEndpoints.Swagger" Version="5.28.0" />
         <PackageReference Include="Nefarius.Utilities.AspNetCore" Version="2.3.0"/>
-        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.2.0" />
+        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.3.0" />
         <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.0.2" />
         <PackageReference Include="Octokit" Version="13.0.1" />
     </ItemGroup>

--- a/examples/server/server.csproj
+++ b/examples/server/server.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="FastEndpoints" Version="5.28.0" />
         <PackageReference Include="FastEndpoints.Swagger" Version="5.28.0" />
         <PackageReference Include="Nefarius.Utilities.AspNetCore" Version="2.3.0"/>
-        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.3.0" />
+        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.3.1" />
         <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.0.2" />
         <PackageReference Include="Octokit" Version="13.0.1" />
     </ItemGroup>

--- a/src/Common.h
+++ b/src/Common.h
@@ -26,6 +26,8 @@
 #define NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE "--terminate-process-before-update"
 #define NV_CLI_IGNORE_POSTPONE                       "--ignore-postpone"
 #define NV_CLI_PURGE_POSTPONE                        "--purge-postpone"
+#define NV_CLI_PARAM_LOCAL_VERSION       "--local-version"
+#define NV_CLI_PARAM_FORCE_LOCAL_VERSION "--force-local-version"
 // internal
 #define NV_CLI_TEMPORARY                             "--temporary"
 

--- a/src/Common.h
+++ b/src/Common.h
@@ -26,8 +26,8 @@
 #define NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE "--terminate-process-before-update"
 #define NV_CLI_IGNORE_POSTPONE                       "--ignore-postpone"
 #define NV_CLI_PURGE_POSTPONE                        "--purge-postpone"
-#define NV_CLI_PARAM_LOCAL_VERSION       "--local-version"
-#define NV_CLI_PARAM_FORCE_LOCAL_VERSION "--force-local-version"
+#define NV_CLI_PARAM_LOCAL_VERSION                   "--local-version"
+#define NV_CLI_PARAM_FORCE_LOCAL_VERSION             "--force-local-version"
 // internal
 #define NV_CLI_TEMPORARY                             "--temporary"
 

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -329,9 +329,13 @@ retry:
 
             if (shared.productName.has_value()) merged.productName = shared.productName.value();
 
-            if (shared.detectionMethod.has_value()) merged.detectionMethod = shared.detectionMethod.value();
+            // special case where we don't want the server to override what the CLI specified
+            if (!this->forceLocalVersion)
+            {
+                if (shared.detectionMethod.has_value()) merged.detectionMethod = shared.detectionMethod.value();
 
-            if (shared.detection.has_value()) merged.detection = shared.detection.value();
+                if (shared.detection.has_value()) merged.detection = shared.detection.value();
+            }
 
             if (shared.installationErrorUrl.has_value()) merged.installationErrorUrl = shared.installationErrorUrl.value();
 

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -331,6 +331,19 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
     }
 #endif
 
+    if (cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION))
+    {
+        // Takes priority over config file; intended for manual debugging/fixing stuff
+        merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
+        merged.detection = cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION).str();
+    }
+    else if (cmdl(NV_CLI_PARAM_LOCAL_VERSION) && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
+    {
+        // Config files take priority; intended for use when launched by an application
+        merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
+        merged.detection = cmdl(NV_CLI_PARAM_LOCAL_VERSION).str();
+    }
+
     // avoid accidental fork bomb :P
     if (this->isTemporaryCopy) this->merged.runAsTemporaryCopy = false;
 
@@ -418,6 +431,29 @@ std::tuple<bool, std::string> models::InstanceConfig::IsInstalledVersionOutdated
 
     switch (merged.detectionMethod)
     {
+        //
+        // We have a fixed version, either from command line, or - presumably local - config file.
+        //
+        case ProductVersionDetectionMethod::FixedVersion:
+        {
+            auto asString = merged.GetFixedVersion();
+            spdlog::debug("Using fixed product version {}", asString);
+            try
+            {
+                util::toSemVerCompatible(asString);
+                const semver::version localVersion = semver::version::parse(asString);
+
+                isOutdated = release.GetDetectionSemVersion() > localVersion;
+                spdlog::debug("isOutdated = {}", isOutdated);
+                return std::make_tuple(true, "OK");
+            }
+            catch (const std::exception& e)
+            {
+                spdlog::error("Failed to convert value {} into SemVer, error: {}", asString, e.what());
+                return std::make_tuple(false, std::format("String to SemVer conversion failed: {}", e.what()));
+            }
+        }
+
         //
         // Detect product version via registry key and value
         //

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -337,13 +337,13 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
     {
         // Takes priority over config file; intended for manual debugging/fixing stuff
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
-        merged.detection = cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION).str();
+        merged.detection = FixedVersionConfig{cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION).str()};
     }
     else if (cmdl[ {NV_CLI_PARAM_LOCAL_VERSION} ] && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
     {
         // Config files take priority; intended for use when launched by an application
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
-        merged.detection = cmdl(NV_CLI_PARAM_LOCAL_VERSION).str();
+        merged.detection = FixedVersionConfig{cmdl(NV_CLI_PARAM_LOCAL_VERSION).str()};
     }
 
     // avoid accidental fork bomb :P

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -331,13 +331,15 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
     }
 #endif
 
-    if (cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION))
+    this->forceLocalVersion = cmdl[ {NV_CLI_PARAM_FORCE_LOCAL_VERSION} ];
+
+    if (this->forceLocalVersion)
     {
         // Takes priority over config file; intended for manual debugging/fixing stuff
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
         merged.detection = cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION).str();
     }
-    else if (cmdl(NV_CLI_PARAM_LOCAL_VERSION) && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
+    else if (cmdl[ {NV_CLI_PARAM_LOCAL_VERSION} ] && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
     {
         // Config files take priority; intended for use when launched by an application
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -331,7 +331,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
     }
 #endif
 
-    this->forceLocalVersion = cmdl[ {NV_CLI_PARAM_FORCE_LOCAL_VERSION} ];
+    this->forceLocalVersion = static_cast<bool>(cmdl({NV_CLI_PARAM_FORCE_LOCAL_VERSION}));
 
     if (this->forceLocalVersion)
     {
@@ -339,7 +339,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;
         merged.detection = FixedVersionConfig{cmdl(NV_CLI_PARAM_FORCE_LOCAL_VERSION).str()};
     }
-    else if (cmdl[ {NV_CLI_PARAM_LOCAL_VERSION} ] && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
+    else if (cmdl({NV_CLI_PARAM_LOCAL_VERSION}) && merged.detectionMethod == ProductVersionDetectionMethod::Invalid)
     {
         // Config files take priority; intended for use when launched by an application
         merged.detectionMethod = ProductVersionDetectionMethod::FixedVersion;

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -438,7 +438,7 @@ std::tuple<bool, std::string> models::InstanceConfig::IsInstalledVersionOutdated
         //
         case ProductVersionDetectionMethod::FixedVersion:
         {
-            auto asString = merged.GetFixedVersion();
+            auto asString = merged.GetFixedVersionConfig().version;
             spdlog::debug("Using fixed product version {}", asString);
             try
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 
     argh::parser cmdl;
 
-    cmdl.add_params({NV_CLI_PARAM_LOG_LEVEL, NV_CLI_PARAM_LOG_TO_FILE, NV_CLI_PARAM_SERVER_URL, NV_CLI_PARAM_CHANNEL,
-                     NV_CLI_PARAM_ADD_HEADER, NV_CLI_PARAM_OVERRIDE_OK, NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE});
+    cmdl.add_params({
+        NV_CLI_PARAM_LOG_LEVEL,
+        NV_CLI_PARAM_LOG_TO_FILE,
+        NV_CLI_PARAM_SERVER_URL,
+        NV_CLI_PARAM_CHANNEL,
+        NV_CLI_PARAM_ADD_HEADER,
+        NV_CLI_PARAM_OVERRIDE_OK,
+        NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE,
+        NV_CLI_PARAM_LOCAL_VERSION,
+        NV_CLI_PARAM_FORCE_LOCAL_VERSION
+    });
 
     if (!util::ParseCommandLineArguments(cmdl))
     {

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -77,6 +77,8 @@ namespace models
         bool ignorePostponePeriod{false};
         /** True if this process is a temporary copy, false if not */
         bool isTemporaryCopy{false};
+        /** True if NV_CLI_PARAM_FORCE_LOCAL_VERSION was specified, false if not */
+        bool forceLocalVersion{false};
 
         // TODO: implement me!
         NSIGINFO appSigInfo{};

--- a/src/models/MergedConfig.hpp
+++ b/src/models/MergedConfig.hpp
@@ -40,6 +40,8 @@ namespace models
         FileChecksumConfig GetFileChecksumConfig() const { return detection.get<FileChecksumConfig>(); }
 
         CustomExpressionConfig GetCustomExpressionConfig() const { return detection.get<CustomExpressionConfig>(); }
+
+        std::string GetFixedVersion() const { return detection.get<std::string>(); }
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(MergedConfig,

--- a/src/models/MergedConfig.hpp
+++ b/src/models/MergedConfig.hpp
@@ -41,7 +41,7 @@ namespace models
 
         CustomExpressionConfig GetCustomExpressionConfig() const { return detection.get<CustomExpressionConfig>(); }
 
-        std::string GetFixedVersion() const { return detection.get<std::string>(); }
+        FixedVersionConfig GetFixedVersionConfig() const { return detection.get<FixedVersionConfig>(); }
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(MergedConfig,

--- a/src/models/ProductDetection.hpp
+++ b/src/models/ProductDetection.hpp
@@ -105,4 +105,16 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(CustomExpressionConfig, input, data)
+
+    /**
+     * \brief A custom expression to evaluate.
+     */
+    class FixedVersionConfig
+    {
+    public:
+        /** The fixed version string */
+        std::string version;
+    };
+
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(FixedVersionConfig, version)
 }

--- a/src/models/ProductDetection.hpp
+++ b/src/models/ProductDetection.hpp
@@ -29,7 +29,7 @@ namespace models
                                  {pvdm::FileSize, magic_enum::enum_name(pvdm::FileSize)},
                                  {pvdm::FileChecksum, magic_enum::enum_name(pvdm::FileChecksum)},
                                  {pvdm::CustomExpression, magic_enum::enum_name(pvdm::CustomExpression)},
-                                   {pvdm::FixedVersion, magic_enum::enum_name(pvdm::FixedVersion)},
+                                 {pvdm::FixedVersion, magic_enum::enum_name(pvdm::FixedVersion)},
                                  })
 
     /**

--- a/src/models/ProductDetection.hpp
+++ b/src/models/ProductDetection.hpp
@@ -16,6 +16,7 @@ namespace models
         FileSize,
         FileChecksum,
         CustomExpression,
+        FixedVersion,
         Invalid = -1
     };
 
@@ -28,6 +29,7 @@ namespace models
                                  {pvdm::FileSize, magic_enum::enum_name(pvdm::FileSize)},
                                  {pvdm::FileChecksum, magic_enum::enum_name(pvdm::FileChecksum)},
                                  {pvdm::CustomExpression, magic_enum::enum_name(pvdm::CustomExpression)},
+                                   {pvdm::FixedVersion, magic_enum::enum_name(pvdm::FixedVersion)},
                                  })
 
     /**


### PR DESCRIPTION
The idea here is to allow config-file-free installations, without requiring that all future versions use the same detection method.

- `--local-version` is intended for coding into programs that launch the updater manually (i.e. no scheduled job); if a config file specifies a version, this takes precedence
- `--force-local-version` takes precedence over the configuration files; this is intended for manually testing/fixing stuff

'FixedVersion' can also be specified in configuration files, presumably only local config files.