### PR TITLE
Support more non-semver formats

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -123,13 +123,23 @@ namespace util
 
     void toSemVerCompatible(std::string& s)
     {
+        const auto notSemver = s;
+        // v1.2.3 -> 1.2.3
+        if (s.starts_with("v"))
+        {
+            s.erase(s.begin());
+        }
         // for 4 digit version we gonna cheat and convert it to a valid semantic version
         if (std::ranges::count_if(s, [](char c) { return c == '.'; }) > 2)
         {
-            s = std::regex_replace(s, std::regex(R"((\d*)\.(\d*)\.(\d*)\.(\d*))"), "$1.$2.$3-rc.$4");
+            s = std::regex_replace(s, std::regex(R"((\d*)\.(\d*)\.(\d*)\.(\d*))"), "$1.$2.$3-revision.$4");
         }
+        // Convert traditional non-semver RC/alphas/betas to semver, e.g. `1.0.0-rc1` -> `1.0.0-rc.1`
+        s = std::regex_replace(s, std::regex(R"(([a-zA-Z_]+)(\d+))"), "$1.$2");
         // Leading zeroes (e.g. in dates like 2024.08.28) aren't valid in semver
         s = std::regex_replace(s, std::regex(R"(\b0*(\d+))"), "$1");
+
+        spdlog::debug("raw version `{}` -> semver string `{}`", notSemver, s);
     }
 
     void stripNulls(std::string& s) { s.erase(std::ranges::find(s, '\0'), s.end()); }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -132,7 +132,7 @@ namespace util
         // for 4 digit version we gonna cheat and convert it to a valid semantic version
         if (std::ranges::count_if(s, [](char c) { return c == '.'; }) > 2)
         {
-            s = std::regex_replace(s, std::regex(R"((\d*)\.(\d*)\.(\d*)\.(\d*))"), "$1.$2.$3-revision.$4");
+            s = std::regex_replace(s, std::regex(R"((\d*)\.(\d*)\.(\d*)\.(\d*))"), "$1.$2.$3+$4");
         }
         // Convert traditional non-semver RC/alphas/betas to semver, e.g. `1.0.0-rc1` -> `1.0.0-rc.1`
         s = std::regex_replace(s, std::regex(R"(([a-zA-Z_]+)(\d+))"), "$1.$2");


### PR DESCRIPTION
- `v1.2.3` -> `1.2.3`
- `1.2.3-rc1` -> `1.2.3-rc.1`
- `v1.2.3-rc1` -> `1.2.3-rc.1`

Renamed quad-version 'rc' field to 'revision', matching *most*
references on MS docs, and disambiguating between strings that actually
specify a version

This builds on top of PR #69 