### PR TITLE
Add NV_CUSTOM_VERSION_SUFFIX

### DIFF
--- a/src/CustomizeMe.h
+++ b/src/CustomizeMe.h
@@ -25,6 +25,17 @@
 #endif
 
 //
+// Customize the updater's own version;
+//
+// for example, if you customize the updater, you probably want to be able to version
+// your customizations, independently of the vicius version.
+//
+// In this case, you could create `v1.7.813+myname1` by specifying '+myname1' here.
+//
+#define NV_CUSTOM_VERSION_SUFFIX ""
+
+
+//
 // Regex for file name extraction, assumes "manufacturer_product_Updater" format
 // Matching value does NOT include file extension
 //

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -233,7 +233,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl) 
 
 #pragma endregion
 
-    appVersion = util::GetVersionFromFile(appPath);
+    appVersion = semver::version::parse(util::GetVersionFromFile(appPath).str() + NV_CUSTOM_VERSION_SUFFIX);
     spdlog::debug("appVersion = {}", appVersion.str());
 
     appFilename = appPath.stem().string();


### PR DESCRIPTION
This allows me to version my customizations, without modifying the Vicius version number itself

For example, my first build may be v1.7.813+fredemmott1; if I customize it more, I'll have v1.7.813+fredemmott2

I don't want to just use a greater version number, as this can conflict/cause confusion with future versions.