### PR TITLE
Update vcpkg baseline to 2024.08.23

### DIFF
--- a/src/vcpkg-configuration.json
+++ b/src/vcpkg-configuration.json
@@ -10,6 +10,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",
-    "baseline": "1de2026f28ead93ff1773e6e680387643e914ea1"
+    "baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da"
   }
 }


### PR DESCRIPTION
Picks up https://github.com/microsoft/vcpkg/commit/f04dfe440cf94fed029a729b5c9fc65575408001

To work around https://github.com/Neargye/magic_enum/issues/373