### PR TITLE
Fix parsing of VERSIONINFO data

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -158,7 +158,10 @@ namespace winapi
             return semver::version{0, 0, 1};
         }
 
-        return semver::version::parse(to_string(versionResult.value()));
+        auto str = to_string(versionResult.value());
+        util::toSemVerCompatible(str);
+
+        return semver::version::parse(str);
     }
 
     semver::version GetWin32ResourceProductVersion(const std::filesystem::path& filePath)
@@ -170,7 +173,9 @@ namespace winapi
             return semver::version{0, 0, 1};
         }
 
-        return semver::version::parse(to_string(versionResult.value()));
+        auto str = to_string(versionResult.value());
+        util::toSemVerCompatible(str);
+        return semver::version::parse(str);
     }
 
     std::string GetLastErrorStdStr(DWORD errorCode)


### PR DESCRIPTION
They're returned in a.b.c.d forms, which isn't valid semver.

Run through the existing function that converts it to a.b.c+d