### PR TITLE
Support the installer closing the updater process

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -63,3 +63,4 @@
 #define NV_S_POSTPONE_PERIOD                         205
 #define NV_S_POSTPONE_PURGE                          206
 #define NV_S_LAUNCHED_TEMPORARY                      207
+#define NV_S_CLOSED_WHILE_UPDATER_RUNNING            208

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,6 +329,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     bool isCancelDisabled = false;
     DWORD status = ERROR_SUCCESS;
     std::once_flag errorUrlTriggered;
+    std::stop_source stopSource;
 
     sf::Clock deltaClock;
     while (window.isOpen())
@@ -341,6 +342,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
             if (event.type == sf::Event::Closed)
             {
                 window.close();
+                stopSource.request_stop();
             }
         }
 
@@ -582,7 +584,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                         break;
                     case DownloadAndInstallStep::PrepareInstall:
                     {
-                        cfg.InvokeSetupAsync();
+                        cfg.InvokeSetupAsync(stopSource.get_token());
 
                         spdlog::debug("Setup process launched asynchronously");
                         instStep = DownloadAndInstallStep::InstallRunning;

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -87,7 +87,7 @@ namespace models
 
         void SetCommonHeaders(_Inout_ RestClient::Connection* conn) const;
 
-        std::tuple<bool, DWORD, DWORD> ExecuteSetup();
+        std::tuple<bool, DWORD, DWORD> ExecuteSetup(const std::stop_token&);
 
     public:
         static constexpr int MAX_TIMEOUT_SECS = 30;
@@ -367,7 +367,7 @@ namespace models
          */
         std::string RenderInjaTemplate(const std::string& tpl, const json& data) const;
 
-        bool InvokeSetupAsync();
+        bool InvokeSetupAsync(const std::stop_token&);
 
         void ResetSetupState();
 


### PR DESCRIPTION
This removes one of the needs for `runAsTemporaryProcess`

- makes it so that the main thread can request cancellation of the updater thread (but not the updater) via an `std::stop_token` (as used by `std::jthread`)
- make this request when the window is closed
- make the wait-for-updater-process code interruptible by this, and set a new exit code

Possible contentious: I added a new 'success' exit code - I can see an argument for it to be considered an error, but given it's in response to a requested action, I think success fits better.