### PR TITLE
Fix check for `..` in channel name

### DIFF
--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -103,7 +103,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
     {
         const auto channelArg = cmdl(NV_CLI_PARAM_CHANNEL).str();
         /* strips "..", "/", "\" and " " */
-        std::regex pathRegex(R"([\.{2}\/\\ ])");
+        std::regex pathRegex(R"(\.{2}|[\/\\ ])");
         this->channel = std::regex_replace(channelArg, pathRegex, "");
     }
 


### PR DESCRIPTION
Stop banning `2` in it :)