### PR TITLE
Remove validation of `--channel` param

### DIFF
--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -101,10 +101,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
     // optional update channel
     if (cmdl({NV_CLI_PARAM_CHANNEL}))
     {
-        const auto channelArg = cmdl(NV_CLI_PARAM_CHANNEL).str();
-        /* strips "..", "/", "\" and " " */
-        std::regex pathRegex(R"(\.{2}|[\/\\ ])");
-        this->channel = std::regex_replace(channelArg, pathRegex, "");
+        this->channel = cmdl(NV_CLI_PARAM_CHANNEL).str();
     }
 
     spdlog::debug("channel = {}", channel);


### PR DESCRIPTION
There isn't a real need for client-side validation here; server-side validation is also needed, and assuming that's there, the worst that happens is a 404.