### PR TITLE
⬆️➕ Update vcpkg dependencies, add missing imgui features

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,9 @@
 find_package(fmt CONFIG REQUIRED)
 find_package(unofficial-hash-library CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
-find_package(ImGui-SFML CONFIG REQUIRED)
 find_package(libzip CONFIG REQUIRED)
 find_package(restclient-cpp CONFIG REQUIRED)
-find_package(SFML COMPONENTS system window graphics CONFIG REQUIRED)
+find_package(directxtk CONFIG REQUIRED)
 
 # vcpkg port of neflib does not define a target
 find_library(NEFLIB_PATH NAMES neflib REQUIRED)
@@ -54,16 +53,16 @@ target_link_libraries(
   PRIVATE
   # vcpkg
   imgui::imgui
-  ImGui-SFML::ImGui-SFML
   fmt::fmt
   libzip::zip
   restclient-cpp
-  sfml-system sfml-graphics sfml-window
   unofficial::hash-library
+  Microsoft::DirectXTK
   "${NEFLIB_PATH}"
   # system
   Comctl32
   crypt32
+  D3D11
   dwmapi
   Propsys
   Rpcrt4

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,12 +3,12 @@
     {
       "kind": "git",
       "repository": "https://github.com/nefarius/nefarius-vcpkg-registry.git",
-      "baseline": "4b47ad975620e164055fd76c2f5e90c9a465993f",
+      "baseline": "a49373c595ad9a64f9b7c935066c1cd59ee960b1",
       "packages": [ "neflib" ]
     }
   ],
   "default-registry": {
     "kind": "builtin",
-    "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
+    "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,9 @@
     {
       "name": "imgui",
       "features": [
+        "dx11-binding",
         "freetype",
+        "win32-binding",
         "wchar32"
       ]
     },


### PR DESCRIPTION
- the previous set can not be installed because the git-tree for neflib versions has changed over time; this breaks vcpkg. Updates to the same version number should use the `port-number` field in `vcpkg.json` to make a new version of the vcpkg with the same dependency version
- added required imgui featires; I'm guessing CI is not using the per-project install so is picking up more featureful versions installed by other projects
- update all of them :)