### PR TITLE
📦 Make CMake-produced release binaries smaller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,30 @@ if(MSVC)
     # Source is UTF-8
     "/utf-8"
   )
+  # MSBuild defaults to these, but CMake doesn't, at least in `RelWithDebInfo` builds
+  # These all make the binary *much* smaller
+  add_link_options(
+    # Incremental linking speeds up rebuilds, which we don't care about for release
+    "$<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>"
+    # COMDAT folding; drops off another 1MB
+    "$<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>"
+    # Remove unused functions and data, in particular, WinRT types
+    "$<$<NOT:$<CONFIG:Debug>>:/OPT:REF>"
+  )
+  # Statically link the *C++* runtime, but dynamically link the UCRT
+  # This gets us most of the benefit of statically linking, but without most of the size costs
+  #
+  # This requires Windows 10 - or, if you're running Windows 7, requires up-to-date
+  # Windows updates, so maybe you don't want this
+  #
+  # Saves ~ 500kb
+  option(ENABLE_HYBRID_CRT "Dynamically link the UCRT (raises OS update requirements)" ON)
+  if (ENABLE_HYBRID_CRT)
+    add_link_options(
+      "/DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib"
+      "/NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib"
+    )
+  endif ()
 endif()
 
 add_subdirectory(dll)


### PR DESCRIPTION
11.1mb -> 5mb (ignoring UPX)

*Most* of this is adding linker flags that are on by default in Visual Studio release builds