### PR TITLE
⬆️ Update vcpkg dependencies

### DIFF
--- a/dll/dll.vcxproj
+++ b/dll/dll.vcxproj
@@ -160,7 +160,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -177,7 +177,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -198,7 +198,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -219,7 +219,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -236,7 +236,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -257,7 +257,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>crypt32.lib;ws2_32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/imgui_md.h
+++ b/src/imgui_md.h
@@ -80,7 +80,7 @@ protected:
 
 	struct image_info
 	{
-		ImTextureID	texture_id;
+		ImTextureRef texture_id;
 		ImVec2	size;
 		ImVec2	uv0;
 		ImVec2	uv1;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -142,7 +142,7 @@ void ui::LoadFonts(HINSTANCE hInstance, const float sizePixels, float scale)
     static ImFontConfig emj_cfg;
     emj_cfg.OversampleH = emj_cfg.OversampleV = 1;
     emj_cfg.MergeMode = true;
-    emj_cfg.FontBuilderFlags |= ImGuiFreeTypeBuilderFlags_LoadColor;
+    emj_cfg.RasterizerFlags |= ImGuiFreeTypeBuilderFlags_LoadColor;
     io.Fonts->AddFontFromFileTTF(emojiFontFile.string().c_str(), scale * sizePixels, &emj_cfg, emj_range);
 
     // Base font bold
@@ -227,5 +227,11 @@ void ui::IndeterminateProgressBar(const ImVec2& size_arg)
 
     RenderFrame(bb.Min, bb.Max, GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
     bb.Expand(ImVec2(-style.FrameBorderSize, -style.FrameBorderSize));
-    RenderRectFilledRangeH(window->DrawList, bb, GetColorU32(ImGuiCol_PlotHistogram), t0, t1, style.FrameRounding);
+    {
+        ImVec2 fill_min(ImLerp(bb.Min.x, bb.Max.x, t0), bb.Min.y);
+        ImVec2 fill_max(ImLerp(bb.Min.x, bb.Max.x, t1), bb.Max.y);
+        window->DrawList->PushClipRect(bb.Min, bb.Max, true);
+        window->DrawList->AddRectFilled(fill_min, fill_max, GetColorU32(ImGuiCol_PlotHistogram), style.FrameRounding);
+        window->DrawList->PopClipRect();
+    }
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -142,7 +142,7 @@ void ui::LoadFonts(HINSTANCE hInstance, const float sizePixels, float scale)
     static ImFontConfig emj_cfg;
     emj_cfg.OversampleH = emj_cfg.OversampleV = 1;
     emj_cfg.MergeMode = true;
-    emj_cfg.RasterizerFlags |= ImGuiFreeTypeBuilderFlags_LoadColor;
+    emj_cfg.FontLoaderFlags |= ImGuiFreeTypeBuilderFlags_LoadColor;
     io.Fonts->AddFontFromFileTTF(emojiFontFile.string().c_str(), scale * sizePixels, &emj_cfg, emj_range);
 
     // Base font bold

--- a/src/vīcĭus.vcxproj
+++ b/src/vīcĭus.vcxproj
@@ -170,7 +170,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>
@@ -195,7 +195,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>
@@ -220,7 +220,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>
@@ -249,7 +249,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>
@@ -278,7 +278,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>
@@ -307,7 +307,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;d3d11.lib;d3dcompiler.lib;dxgi.lib;Rpcrt4.lib;Comctl32.lib;taskschd.lib;comsupp.lib;version.lib;crypt32.lib;ws2_32.lib;iphlpapi.lib;bcrypt.lib;secur32.lib;winmm.lib;dwmapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalOptions>/D SELF_UPDATER_PATH="selfupdater\$(PlatformShortName)\selfupdater.dll"</AdditionalOptions>

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,12 +3,12 @@
     {
       "kind": "git",
       "repository": "https://github.com/nefarius/nefarius-vcpkg-registry.git",
-      "baseline": "a49373c595ad9a64f9b7c935066c1cd59ee960b1",
+      "baseline": "7ba0e21dc3f4bdef654480e5060621b01a110ebf",
       "packages": [ "neflib" ]
     }
   ],
   "default-registry": {
     "kind": "builtin",
-    "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+    "baseline": "2b65c20fc66eda893aa15a15a453c3cf09500b19"
   }
 }


### PR DESCRIPTION
- Bump builtin baseline to 2b65c20 (2026-05-16, microsoft/vcpkg master)
- Bump nefarius registry baseline to 7ba0e21 (2025-10-05, neflib 1.3.2)
- Advance vcpkg submodule pointer to match new builtin baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager reference and refreshed registry baselines; adjusted Windows linker dependencies to include additional system libraries for improved build compatibility and linkage.
  * Updated image texture handling for compatibility with the UI backend.

* **UI Improvements**
  * Improved emoji font loading and refined indeterminate progress bar rendering with explicit clipping and smoother, more consistent fill visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/vicius/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->