### PR TITLE
Add secure update verification and signature checks

### DIFF
--- a/.cursor/rules/cpp-error-handling.mdc
+++ b/.cursor/rules/cpp-error-handling.mdc
@@ -1,0 +1,73 @@
+---
+description: C++ error handling conventions — prefer std::expected over tuples or exceptions
+globs: "**/*.cpp,**/*.h,**/*.hpp"
+alwaysApply: true
+---
+
+# Error Handling
+
+Prefer `std::expected<T, std::string>` (already included via `<expected>` in `pch.h`) for all fallible operations that need to return a value or a human-readable failure reason.
+
+## Return type selection
+
+| Scenario | Type |
+|---|---|
+| Success produces a value | `std::expected<T, std::string>` |
+| Success produces nothing | `std::expected<void, std::string>` |
+| Unrecoverable, program must exit | `[[noreturn]]` + log + `std::terminate` |
+| Precondition violation (always a bug) | `assert` / `_ASSERT` |
+
+## ❌ Don't
+
+```cpp
+// tuple-bool anti-pattern
+std::tuple<bool, std::string> Foo();
+auto [ok, reason] = Foo();
+if (!ok) { ... }
+
+// naked exceptions for control flow
+throw std::runtime_error("something failed");
+```
+
+## ✅ Do
+
+```cpp
+std::expected<Widget, std::string> BuildWidget();
+
+// success
+return Widget{...};
+
+// failure
+return std::unexpected("Widget source not found");
+
+// caller
+if (auto w = BuildWidget())
+    Use(*w);
+else
+    spdlog::error("BuildWidget failed: {}", w.error());
+```
+
+## `void` specialisation (no return value on success)
+
+```cpp
+std::expected<void, std::string> VerifyFile(const std::filesystem::path& p);
+
+// success
+return {};
+
+// failure
+return std::unexpected("File is not signed");
+
+// caller
+if (auto r = VerifyFile(path); !r)
+    return std::unexpected(r.error()); // propagate
+```
+
+## Propagation shorthand
+
+Chain failures without re-wrapping manually:
+
+```cpp
+auto inner = DoInnerWork();
+if (!inner) return std::unexpected(inner.error());
+```

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -3,6 +3,12 @@
 
 #include "framework.h"
 #include "dll.h"
+#include <wintrust.h>
+#include <softpub.h>
+#include <bcrypt.h>
+
+#pragma comment(lib, "wintrust.lib")
+#pragma comment(lib, "bcrypt.lib")
 
 static std::string ConvertWideToANSI(const std::wstring& wstr)
 {
@@ -11,6 +17,171 @@ static std::string ConvertWideToANSI(const std::wstring& wstr)
     std::string str(count, 0);
     WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &str[0], count, nullptr, nullptr);
     return str;
+}
+
+// ============================================================================
+// Checksum helpers (BCrypt-based, no external hash library dependency)
+// ============================================================================
+
+static bool ComputeFileSHA256(const std::filesystem::path& filePath, std::string& outHex)
+{
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+    std::vector<BYTE> hashObj, hashBuf;
+
+    if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
+        return false;
+
+    auto cleanAlg = [&]{ if (hAlg) { BCryptCloseAlgorithmProvider(hAlg, 0); hAlg = nullptr; } };
+
+    DWORD objLen = 0, hashLen = 0, result = 0;
+    if (BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, (PUCHAR)&objLen, sizeof(DWORD), &result, 0) != 0)
+    { cleanAlg(); return false; }
+    if (BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH, (PUCHAR)&hashLen, sizeof(DWORD), &result, 0) != 0)
+    { cleanAlg(); return false; }
+
+    hashObj.resize(objLen);
+    hashBuf.resize(hashLen);
+
+    if (BCryptCreateHash(hAlg, &hHash, hashObj.data(), objLen, nullptr, 0, 0) != 0)
+    { cleanAlg(); return false; }
+
+    auto cleanHash = [&]{ if (hHash) { BCryptDestroyHash(hHash); hHash = nullptr; } };
+
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file.is_open()) { cleanHash(); cleanAlg(); return false; }
+
+    constexpr std::size_t chunkSize = 65536;
+    std::vector<BYTE> buf(chunkSize);
+    while (!file.eof())
+    {
+        file.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(chunkSize));
+        const std::streamsize n = file.gcount();
+        if (n > 0 && BCryptHashData(hHash, buf.data(), static_cast<ULONG>(n), 0) != 0)
+        { cleanHash(); cleanAlg(); return false; }
+    }
+
+    if (BCryptFinishHash(hHash, hashBuf.data(), hashLen, 0) != 0)
+    { cleanHash(); cleanAlg(); return false; }
+
+    cleanHash();
+    cleanAlg();
+
+    std::string hex;
+    hex.reserve(hashLen * 2);
+    for (DWORD i = 0; i < hashLen; ++i)
+    {
+        char nibbles[3];
+        std::snprintf(nibbles, sizeof(nibbles), "%02x", hashBuf[i]);
+        hex += nibbles;
+    }
+    outHex = std::move(hex);
+    return true;
+}
+
+static bool ComputeFileSHA1(const std::filesystem::path& filePath, std::string& outHex)
+{
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+    std::vector<BYTE> hashObj, hashBuf;
+
+    if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA1_ALGORITHM, nullptr, 0) != 0)
+        return false;
+
+    auto cleanAlg = [&]{ if (hAlg) { BCryptCloseAlgorithmProvider(hAlg, 0); hAlg = nullptr; } };
+
+    DWORD objLen = 0, hashLen = 0, result = 0;
+    if (BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, (PUCHAR)&objLen, sizeof(DWORD), &result, 0) != 0)
+    { cleanAlg(); return false; }
+    if (BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH, (PUCHAR)&hashLen, sizeof(DWORD), &result, 0) != 0)
+    { cleanAlg(); return false; }
+
+    hashObj.resize(objLen);
+    hashBuf.resize(hashLen);
+
+    if (BCryptCreateHash(hAlg, &hHash, hashObj.data(), objLen, nullptr, 0, 0) != 0)
+    { cleanAlg(); return false; }
+
+    auto cleanHash = [&]{ if (hHash) { BCryptDestroyHash(hHash); hHash = nullptr; } };
+
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file.is_open()) { cleanHash(); cleanAlg(); return false; }
+
+    constexpr std::size_t chunkSize = 65536;
+    std::vector<BYTE> buf(chunkSize);
+    while (!file.eof())
+    {
+        file.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(chunkSize));
+        const std::streamsize n = file.gcount();
+        if (n > 0 && BCryptHashData(hHash, buf.data(), static_cast<ULONG>(n), 0) != 0)
+        { cleanHash(); cleanAlg(); return false; }
+    }
+
+    if (BCryptFinishHash(hHash, hashBuf.data(), hashLen, 0) != 0)
+    { cleanHash(); cleanAlg(); return false; }
+
+    cleanHash();
+    cleanAlg();
+
+    std::string hex;
+    hex.reserve(hashLen * 2);
+    for (DWORD i = 0; i < hashLen; ++i)
+    {
+        char nibbles[3];
+        std::snprintf(nibbles, sizeof(nibbles), "%02x", hashBuf[i]);
+        hex += nibbles;
+    }
+    outHex = std::move(hex);
+    return true;
+}
+
+// ============================================================================
+// Authenticode helpers (WinVerifyTrust - revocation checked, no lifetime flag)
+// ============================================================================
+
+static bool VerifyAuthenticode(const std::wstring& filePath)
+{
+    WINTRUST_FILE_INFO fileInfo = {};
+    fileInfo.cbStruct = sizeof(WINTRUST_FILE_INFO);
+    fileInfo.pcwszFilePath = filePath.c_str();
+    fileInfo.hFile = nullptr;
+    fileInfo.pgKnownSubject = nullptr;
+
+    GUID wvtPolicyGuid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+
+    WINTRUST_DATA wtData = {};
+    wtData.cbStruct = sizeof(WINTRUST_DATA);
+    wtData.pPolicyCallbackData = nullptr;
+    wtData.pSIPClientData = nullptr;
+    wtData.dwUIChoice = WTD_UI_NONE;
+    wtData.fdwRevocationChecks = WTD_REVOKE_WHOLECHAIN;
+    wtData.dwUnionChoice = WTD_CHOICE_FILE;
+    wtData.pFile = &fileInfo;
+    wtData.dwStateAction = WTD_STATEACTION_VERIFY;
+    wtData.hWVTStateData = nullptr;
+    wtData.pwszURLReference = nullptr;
+    // Do NOT set WTD_LIFETIME_SIGNING so time-stamped expired certs remain valid
+    wtData.dwProvFlags = WTD_REVOCATION_CHECK_CHAIN;
+    wtData.dwUIContext = 0;
+
+    const LONG lStatus = WinVerifyTrust(nullptr, &wvtPolicyGuid, &wtData);
+
+    // Release state data
+    wtData.dwStateAction = WTD_STATEACTION_CLOSE;
+    WinVerifyTrust(nullptr, &wvtPolicyGuid, &wtData);
+
+    return lStatus == ERROR_SUCCESS;
+}
+
+// ============================================================================
+// Case-insensitive hex string comparison (for checksum matching)
+// ============================================================================
+static bool IHexEqual(const std::string& a, const std::string& b)
+{
+    if (a.size() != b.size()) return false;
+    return std::equal(a.begin(), a.end(), b.begin(),
+                      [](unsigned char ca, unsigned char cb)
+                      { return std::tolower(ca) == std::tolower(cb); });
 }
 
 static std::string GetRandomString()
@@ -58,9 +229,11 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
     argh::parser cmdl;
 
     cmdl.add_params({
-        "--pid", // PID of the parent process
-        "--url", // latest updater download URL
-        "--path", // the target file path
+        "--pid",           // PID of the parent process
+        "--url",           // latest updater download URL
+        "--path",          // the target file path
+        "--checksum",      // expected SHA256 hex digest of downloaded file
+        "--checksum-alg",  // checksum algorithm: sha256 (default), sha1
         "--log-level"
     });
 
@@ -120,15 +293,39 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
         return;
     }
 
+    // Optional integrity parameters
+    const std::string expectedChecksum = cmdl({"--checksum"}).str();
+    const std::string checksumAlg = [&]
+    {
+        const std::string alg = cmdl({"--checksum-alg"}).str();
+        return alg.empty() ? std::string("sha256") : alg;
+    }();
+
+    if (!expectedChecksum.empty())
+    {
+        spdlog::info("Checksum verification requested: alg={} expected={}", checksumAlg, expectedChecksum);
+    }
+    else
+    {
+        spdlog::warn("No --checksum provided; self-update will proceed without checksum verification");
+    }
+
     std::filesystem::path original = cmdl({"--path"}).str();
     spdlog::debug("original = {}", original.string());
     const auto workDir = original.parent_path();
-    // hint: we must remain on the same drive, or renaming will fail!
-    std::filesystem::path randomName(GetRandomString());
-    spdlog::debug("randomName = {}", randomName.string());
-    std::filesystem::path temp = original.parent_path() / randomName;
-    std::string tempFile = temp.string();
-    spdlog::debug("tempFile = {}", tempFile);
+
+    // Backup name - remains on same drive so rename is atomic
+    std::filesystem::path backupName(GetRandomString() + ".bak");
+    std::filesystem::path backup = workDir / backupName;
+    std::string backupFile = backup.string();
+    spdlog::debug("backup = {}", backupFile);
+
+    // Download to a separate temp file first, then verify before swapping
+    std::filesystem::path downloadName(GetRandomString() + ".tmp");
+    std::filesystem::path downloadPath = workDir / downloadName;
+    std::string downloadFile = downloadPath.string();
+    spdlog::debug("downloadFile = {}", downloadFile);
+
     curlpp::Cleanup myCleanup;
     HANDLE hProcess = nullptr;
     int retries = 20; // 2 seconds timeout
@@ -173,39 +370,147 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
     }
     while (hProcess);
 
-    spdlog::debug("Preparing download");
+    spdlog::debug("Preparing download to temp file");
 
     std::ofstream outStream;
     const std::ios_base::iostate exceptionMask = outStream.exceptions() | std::ios::failbit;
     outStream.exceptions(exceptionMask);
 
-    try
+    auto RestoreBackup = [&]()
     {
-        // we can not yet directly write to it but move it to free the original name!
-        MoveFileA(original.string().c_str(), tempFile.c_str());
-        SetFileAttributesA(tempFile.c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM);
-        spdlog::debug("Moved file {} to hidden file {}", original.string(), tempFile);
-
-        spdlog::debug("Starting download");
-        // download directly to main file stream
-        outStream.open(original, std::ios::binary | std::ofstream::ate);
-        outStream << curlpp::options::Url(url);
-
-        spdlog::info("Downloading {} finished", url);
-
-        if (DeleteFileA(tempFile.c_str()) == FALSE)
+        // Restore original from backup on failure
+        if (std::filesystem::exists(backup))
         {
-            spdlog::warn("Failed to delete file {}, scheduling removal on reboot", tempFile);
-
-            // if it still fails, schedule nuking the old file at next reboot
-            MoveFileExA(
-                tempFile.c_str(),
-                nullptr,
-                MOVEFILE_DELAY_UNTIL_REBOOT
-            );
+            CopyFileA(backupFile.c_str(), original.string().c_str(), FALSE);
+            SetFileAttributesA(original.string().c_str(), FILE_ATTRIBUTE_NORMAL);
+            spdlog::info("Restored backup to {}", original.string());
         }
 
+        // Clean up the downloaded temp file if it exists
+        if (std::filesystem::exists(downloadPath))
+        {
+            if (DeleteFileA(downloadFile.c_str()) == FALSE)
+            {
+                MoveFileExA(downloadFile.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+            }
+        }
+
+        // Schedule backup removal (it's now either restored or no longer needed)
+        if (std::filesystem::exists(backup))
+        {
+            if (DeleteFileA(backupFile.c_str()) == FALSE)
+            {
+                MoveFileExA(backupFile.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+            }
+        }
+    };
+
+    try
+    {
+        // Move the original to a hidden backup (frees the target filename for the final rename)
+        MoveFileA(original.string().c_str(), backupFile.c_str());
+        SetFileAttributesA(backupFile.c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM);
+        spdlog::debug("Moved original {} to backup {}", original.string(), backupFile);
+
+        // Download to the separate temp file (NOT the original location yet)
+        spdlog::info("Downloading {} to {}", url, downloadFile);
+        outStream.open(downloadPath, std::ios::binary | std::ofstream::ate);
+        outStream << curlpp::options::Url(url);
         outStream.close();
+        spdlog::info("Download finished");
+
+        // ----------------------------------------------------------------
+        // Integrity verification before swap
+        // ----------------------------------------------------------------
+
+        // 1. Checksum verification
+        if (!expectedChecksum.empty())
+        {
+            std::string computed;
+            bool hashOk = false;
+
+            if (checksumAlg == "sha256" || checksumAlg.empty())
+            {
+                hashOk = ComputeFileSHA256(downloadPath, computed);
+            }
+            else if (checksumAlg == "sha1")
+            {
+                hashOk = ComputeFileSHA1(downloadPath, computed);
+            }
+            else
+            {
+                spdlog::error("Unknown checksum algorithm: {}", checksumAlg);
+                RestoreBackup();
+                if (!silent)
+                    MessageBoxA(hwnd, "Unknown checksum algorithm in self-update arguments.",
+                                "Self-update verification failed", MB_ICONERROR | MB_OK);
+                return;
+            }
+
+            if (!hashOk)
+            {
+                spdlog::error("Failed to compute checksum of downloaded file {}", downloadFile);
+                RestoreBackup();
+                if (!silent)
+                    MessageBoxA(hwnd, "Failed to compute checksum of the downloaded updater binary.",
+                                "Self-update verification failed", MB_ICONERROR | MB_OK);
+                return;
+            }
+
+            spdlog::debug("Checksum: computed={} expected={}", computed, expectedChecksum);
+
+            if (!IHexEqual(computed, expectedChecksum))
+            {
+                spdlog::error("Checksum MISMATCH: computed {} != expected {}", computed, expectedChecksum);
+                RestoreBackup();
+                if (!silent)
+                    MessageBoxA(hwnd,
+                                "The downloaded updater binary checksum does not match the expected value.\n"
+                                "The download may have been corrupted or tampered with.",
+                                "Self-update verification failed", MB_ICONERROR | MB_OK);
+                return;
+            }
+
+            spdlog::info("Checksum verification PASSED");
+        }
+
+        // 2. Authenticode / WinVerifyTrust verification
+        const bool sigOk = VerifyAuthenticode(downloadPath.wstring());
+
+        if (!sigOk)
+        {
+            // An unsigned binary is treated as suspicious in self-update context
+            spdlog::error("Authenticode verification FAILED for downloaded updater binary {}", downloadFile);
+            RestoreBackup();
+            if (!silent)
+                MessageBoxA(hwnd,
+                            "The downloaded updater binary does not have a valid Authenticode signature.\n"
+                            "Self-update has been aborted for security reasons.",
+                            "Self-update verification failed", MB_ICONERROR | MB_OK);
+            return;
+        }
+
+        spdlog::info("Authenticode verification PASSED");
+
+        // ----------------------------------------------------------------
+        // Verification passed - swap into place
+        // ----------------------------------------------------------------
+        if (!MoveFileA(downloadFile.c_str(), original.string().c_str()))
+        {
+            spdlog::error("Failed to rename {} to {} (error: {})",
+                          downloadFile, original.string(), GetLastError());
+            RestoreBackup();
+            return;
+        }
+
+        spdlog::info("Swapped verified download into {}", original.string());
+
+        // Clean up the backup
+        if (DeleteFileA(backupFile.c_str()) == FALSE)
+        {
+            spdlog::warn("Failed to delete backup {}, scheduling removal on reboot", backupFile);
+            MoveFileExA(backupFile.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+        }
 
         spdlog::info("Spawning main process install procedure");
 
@@ -266,22 +571,10 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
     }
     catch (...)
     {
-        // welp
+        spdlog::error("Unknown error during self-update");
     }
 
-    // restore original file on failure
-    CopyFileA(tempFile.c_str(), original.string().c_str(), FALSE);
-    SetFileAttributesA(original.string().c_str(), FILE_ATTRIBUTE_NORMAL);
-    // attempt to delete temporary copy
-    if (DeleteFileA(tempFile.c_str()) == FALSE)
-    {
-        // if it still fails, schedule nuking the old file at next reboot
-        MoveFileExA(
-            tempFile.c_str(),
-            nullptr,
-            MOVEFILE_DELAY_UNTIL_REBOOT
-        );
-    }
-
-    spdlog::warn("Finished with warning or errors");
+    // Restore original on any unhandled failure
+    RestoreBackup();
+    spdlog::warn("Finished with errors - original binary restored");
 }

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -53,12 +53,17 @@ static bool ComputeFileSHA256(const std::filesystem::path& filePath, std::string
 
     constexpr std::size_t chunkSize = 65536;
     std::vector<BYTE> buf(chunkSize);
-    while (!file.eof())
+    for (;;)
     {
         file.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(chunkSize));
         const std::streamsize n = file.gcount();
         if (n > 0 && BCryptHashData(hHash, buf.data(), static_cast<ULONG>(n), 0) != 0)
         { cleanHash(); cleanAlg(); return false; }
+        if (!file)
+        {
+            if (!file.eof()) { cleanHash(); cleanAlg(); return false; } // I/O error, not clean EOF
+            break;
+        }
     }
 
     if (BCryptFinishHash(hHash, hashBuf.data(), hashLen, 0) != 0)
@@ -109,12 +114,17 @@ static bool ComputeFileSHA1(const std::filesystem::path& filePath, std::string& 
 
     constexpr std::size_t chunkSize = 65536;
     std::vector<BYTE> buf(chunkSize);
-    while (!file.eof())
+    for (;;)
     {
         file.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(chunkSize));
         const std::streamsize n = file.gcount();
         if (n > 0 && BCryptHashData(hHash, buf.data(), static_cast<ULONG>(n), 0) != 0)
         { cleanHash(); cleanAlg(); return false; }
+        if (!file)
+        {
+            if (!file.eof()) { cleanHash(); cleanAlg(); return false; } // I/O error, not clean EOF
+            break;
+        }
     }
 
     if (BCryptFinishHash(hHash, hashBuf.data(), hashLen, 0) != 0)
@@ -378,15 +388,7 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
 
     auto RestoreBackup = [&]()
     {
-        // Restore original from backup on failure
-        if (std::filesystem::exists(backup))
-        {
-            CopyFileA(backupFile.c_str(), original.string().c_str(), FALSE);
-            SetFileAttributesA(original.string().c_str(), FILE_ATTRIBUTE_NORMAL);
-            spdlog::info("Restored backup to {}", original.string());
-        }
-
-        // Clean up the downloaded temp file if it exists
+        // Clean up the failed download temp file first (it is always disposable).
         if (std::filesystem::exists(downloadPath))
         {
             if (DeleteFileA(downloadFile.c_str()) == FALSE)
@@ -395,12 +397,27 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
             }
         }
 
-        // Schedule backup removal (it's now either restored or no longer needed)
+        // Restore original from backup.  Only remove the backup after a confirmed copy;
+        // if CopyFileA fails, keep the backup intact so the user can recover manually.
         if (std::filesystem::exists(backup))
         {
-            if (DeleteFileA(backupFile.c_str()) == FALSE)
+            if (CopyFileA(backupFile.c_str(), original.string().c_str(), FALSE) != FALSE)
             {
-                MoveFileExA(backupFile.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+                SetFileAttributesA(original.string().c_str(), FILE_ATTRIBUTE_NORMAL);
+                spdlog::info("Restored backup to {}", original.string());
+
+                // Backup is no longer needed - remove it.
+                if (DeleteFileA(backupFile.c_str()) == FALSE)
+                {
+                    MoveFileExA(backupFile.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+                }
+            }
+            else
+            {
+                spdlog::error("CRITICAL: failed to restore {} from backup {} (error: {}). "
+                              "The backup is preserved at that path for manual recovery.",
+                              original.string(), backupFile, GetLastError());
+                // Do NOT delete the backup - it is the only good copy left.
             }
         }
     };

--- a/dll/framework.h
+++ b/dll/framework.h
@@ -11,10 +11,14 @@
 #include <shellapi.h>
 
 #include <filesystem>
+#include <format>
+#include <sstream>
 #include <string>
 #include <fstream>
 #include <algorithm>
 #include <random>
+#include <vector>
+#include <functional>
 #define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING 1
 #include <locale>
 

--- a/docs/SECURE_UPDATE_PIPELINE.md
+++ b/docs/SECURE_UPDATE_PIPELINE.md
@@ -155,15 +155,76 @@ Open `src/CustomizeMe.h` and uncomment + fill in the second line of your `.pub` 
 
 When `NV_MANIFEST_PUBLIC_KEY` is defined, manifest verification is **mandatory**.
 
+### Install minisign (Windows)
+
+`minisign` is an open-source signing tool by Frank Denis (the libsodium author)
+that produces Ed25519 keypairs and the `.minisig` detached signature files that
+the updater verifies.
+
+```powershell
+# winget (built into Windows 11 / updated Windows 10)
+winget install jedisct1.minisign
+
+# Scoop
+scoop install minisign
+
+# Chocolatey
+choco install minisign
+```
+
+Alternatively, download the pre-built `.zip` from the
+[minisign releases page](https://github.com/jedisct1/minisign/releases) and put
+`minisign.exe` on your `PATH`.
+
+### Generate a keypair (one-time)
+
+```powershell
+minisign -G
+# Writes:
+#   ~/.minisign/minisign.key   <- private key, keep secret
+#   ~/.minisign/minisign.pub   <- public key, second line goes into CustomizeMe.h
+```
+
+The public key file looks like:
+
+```text
+untrusted comment: minisign public key ABCDEF1234567890
+RWSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Copy the second line (`RWS...`) into `src/CustomizeMe.h`:
+
+```cpp
+#define NV_MANIFEST_PUBLIC_KEY  "RWSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+Rebuild the updater.  From this point on, manifests without a valid `.minisig`
+are rejected at runtime.
+
 ### Sign the manifest on every publish
 
-```sh
-minisign -S -s ~/.minisign/minisign.key -m updates.json
+```powershell
+minisign -S -s "$env:USERPROFILE\.minisign\minisign.key" -m updates.json
 # produces updates.json.minisig alongside updates.json
 ```
 
-Serve both files from the same URL base.  The updater automatically fetches
-`<manifestUrl>.minisig` and verifies it before parsing the JSON.
+Serve both files from the same URL base.  The updater fetches
+`<manifestUrl>.minisig` automatically and verifies it before parsing the JSON.
+
+### Verify locally (sanity check)
+
+```powershell
+minisign -V -p minisign.pub -m updates.json
+```
+
+### Operations reference
+
+| Topic | Detail |
+|---|---|
+| Keypair rotation | Generate a new pair, recompile with the new public key, ship a new updater build. |
+| Authenticode cert renewal | No action needed — the Ed25519 key is independent of the X.509 cert lifecycle. |
+| CI / automated signing | Store `minisign.key` as a CI secret; add `minisign -S ...` as the final step of your manifest publish pipeline. Use `-W` to create a passphrase-less key for unattended signing. |
+| Passphrase | `minisign -G` prompts for a passphrase; use `-W` to skip it for CI environments. |
 
 ### Rollback / downgrade protection
 

--- a/docs/SECURE_UPDATE_PIPELINE.md
+++ b/docs/SECURE_UPDATE_PIPELINE.md
@@ -6,7 +6,7 @@ This document describes the five-layer defense-in-depth model implemented in vic
 
 ## Architecture overview
 
-```
+```text
 Fetch updates.json over TLS
          │
          ▼
@@ -35,8 +35,12 @@ Fetch updates.json over TLS
  Run setup / extract zip
 ```
 
-Each layer is independently opt-in so existing deployments keep working while
-tenants migrate to stricter settings.
+Most layers are independently opt-in so existing deployments keep working while
+tenants migrate to stricter settings.  **Exception: Layer 5 (HTTPS enforcement)
+is always active in release builds.**  Existing tenants whose `downloadUrl` or
+`latestUrl` values use plain `http://` must migrate those URLs to `https://`
+before shipping an updater built with this code, or they will break silently for
+all deployed clients.
 
 ---
 
@@ -209,9 +213,23 @@ To supply a checksum for the self-updater binary, add `latestChecksum` to the
 
 ## Layer 5 — URL scheme enforcement
 
-`downloadUrl` and `latestUrl` must use `https://`.  Plain `http://`, `file://`,
-and any other scheme are rejected.  In debug builds (`!NDEBUG`), HTTP to localhost
-(`127.0.0.1`, `[::1]`) is permitted for local test servers.
+`downloadUrl` (per release) and `latestUrl` (self-updater) **must use `https://`**
+in release builds.  Plain `http://`, `file://`, and any other scheme are rejected
+immediately after the manifest is parsed — before any download starts.
+
+> **Migration required for existing HTTP tenants.**  Any deployment whose manifest
+> contains `http://` download URLs will start failing once the updater is rebuilt
+> with this code.  Move those URLs to `https://` before shipping.
+
+### Allowed exceptions
+
+| Condition | Allowed URLs |
+|---|---|
+| Debug build (`!NDEBUG`) | `http://localhost`, `http://127.0.0.1`, `http://[::1]` |
+| Compile-time flag `NV_FLAGS_ALLOW_HTTP_DOWNLOAD` | Same localhost addresses as above |
+
+`NV_FLAGS_ALLOW_HTTP_DOWNLOAD` is intended for CI/integration-test pipelines that
+spin up a local HTTP server.  It must never be set in production builds.
 
 ---
 

--- a/docs/SECURE_UPDATE_PIPELINE.md
+++ b/docs/SECURE_UPDATE_PIPELINE.md
@@ -1,0 +1,231 @@
+# Secure Update Pipeline
+
+This document describes the five-layer defense-in-depth model implemented in vicius and how to configure each layer.
+
+---
+
+## Architecture overview
+
+```
+Fetch updates.json over TLS
+         │
+         ▼
+ [Layer 3] Ed25519 manifest signature valid? (NV_MANIFEST_PUBLIC_KEY compiled in)
+         │ no  → abort
+         │ yes
+         ▼
+ Parse and trust manifest
+         │
+         ▼
+ [Layer 5] HTTPS enforced on all downloadUrl / latestUrl
+         │ non-HTTPS → abort
+         │
+         ▼
+ Download setup over HTTPS
+         │
+         ▼
+ [Layer 1] Setup checksum matches manifest? (release.checksum)
+         │ mismatch → abort
+         │
+         ▼
+ [Layer 2] Authenticode chain valid AND publisher pinned?
+         │ no  → abort (in Required / Strict mode)
+         │ yes
+         ▼
+ Run setup / extract zip
+```
+
+Each layer is independently opt-in so existing deployments keep working while
+tenants migrate to stricter settings.
+
+---
+
+## Layer 1 — Setup checksum (always-on when provided)
+
+Add a `checksum` block to each release entry:
+
+```json
+{
+  "releases": [
+    {
+      "checksum": {
+        "checksum": "<sha256-hex>",
+        "checksumAlg": "SHA256"
+      }
+    }
+  ]
+}
+```
+
+Supported algorithms: `MD5`, `SHA1`, `SHA256`.
+
+When a checksum is present it **must** match before the setup is executed.
+When absent:
+- **Relaxed mode** (default): allowed, a warning is logged.
+- **Strict mode** (`--strict-verification` CLI): the setup is rejected.
+
+---
+
+## Layer 2 — Authenticode publisher pinning
+
+### Global settings (`shared` block)
+
+```json
+{
+  "shared": {
+    "signatureVerificationMode": "WhenPresent",
+    "signaturePolicy": "Relaxed",
+    "signatureStrategy": "FromUpdaterBinary"
+  }
+}
+```
+
+| Field | Values | Default |
+|---|---|---|
+| `signatureVerificationMode` | `Disabled`, `WhenPresent`, `Required` | `WhenPresent` |
+| `signaturePolicy` | `Relaxed` (chain only), `Strict` (chain + pin) | `Relaxed` |
+| `signatureStrategy` | `FromUpdaterBinary`, `FromConfiguration` | `FromUpdaterBinary` |
+
+### FromUpdaterBinary (default, renewal-safe)
+
+The setup's signing certificate subject name is compared against the updater exe's
+own subject name.  **Only `subjectName` is compared** — this field is stable across
+certificate renewals (tied to your legal entity).
+
+### FromConfiguration (explicit pin)
+
+Supply an explicit pin in the `signatureConfig` block.  Because this travels inside
+the signed manifest (Layer 3), rotating it on cert renewal is safe:
+
+```json
+{
+  "shared": {
+    "signatureVerificationMode": "Required",
+    "signaturePolicy": "Strict",
+    "signatureStrategy": "FromConfiguration",
+    "signatureConfig": {
+      "subjectName": "My Company, Inc.",
+      "issuerName":  "DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1"
+    }
+  }
+}
+```
+
+Per-release overrides are also supported (add `signature`, `signaturePolicy`,
+`signatureStrategy` inside the release object).
+
+### Certificate renewal runbook
+
+> **Non-negotiable anti-brick guarantee:** an updater that statically pins serial /
+> thumbprint will mass-lockout all deployed clients when the cert renews.
+
+Safe renewal procedure for Strict/FromConfiguration:
+
+1. Sign the new manifest (with cert B's identity) **while cert A is still valid**.
+2. Publish an updated `signatureConfig` with cert B's `subjectName` (or add
+   `serialNumber`/`thumbprint` if you want extra-strict pinning).
+3. Sign and publish the manifest with the Ed25519 key (same key — no redeploy).
+4. Deployed clients accept cert B through the manifest before you stop using cert A.
+
+If you use **`FromUpdaterBinary`** with `subjectName` comparison only, no action is
+needed on renewal — the organization name doesn't change.
+
+---
+
+## Layer 3 — Ed25519 / minisign manifest signature
+
+### Generate a keypair
+
+```sh
+minisign -G
+# writes ~/.minisign/minisign.key  and  ~/.minisign/minisign.pub
+```
+
+### Compile the public key into the updater
+
+Open `src/CustomizeMe.h` and uncomment + fill in the second line of your `.pub` file:
+
+```cpp
+#define NV_MANIFEST_PUBLIC_KEY  "RWSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+When `NV_MANIFEST_PUBLIC_KEY` is defined, manifest verification is **mandatory**.
+
+### Sign the manifest on every publish
+
+```sh
+minisign -S -s ~/.minisign/minisign.key -m updates.json
+# produces updates.json.minisig alongside updates.json
+```
+
+Serve both files from the same URL base.  The updater automatically fetches
+`<manifestUrl>.minisig` and verifies it before parsing the JSON.
+
+### Rollback / downgrade protection
+
+Add a monotonically increasing `manifestVersion` integer to the root of the manifest:
+
+```json
+{
+  "manifestVersion": 42,
+  ...
+}
+```
+
+Deployed clients persist the highest version seen in the registry and reject
+manifests with a lower value (downgrade / replay attack).
+
+---
+
+## Layer 4 — Self-updater hardening
+
+The self-updater DLL (`dll/dll.cpp`) now:
+
+1. Downloads the new updater binary to a **temporary file** (not the final path).
+2. Verifies the **checksum** (`--checksum` / `--checksum-alg` CLI args, forwarded
+   from the signed manifest via `instance.latestChecksum`).
+3. Verifies the **Authenticode signature** using WinVerifyTrust (revocation checked,
+   no `WTD_LIFETIME_SIGNING_FLAG` — timestamped expired certs remain valid).
+4. Only on success: atomically swaps the temp file into the final path.
+5. On any failure: restores the original binary from the hidden backup.
+
+To supply a checksum for the self-updater binary, add `latestChecksum` to the
+`instance` block:
+
+```json
+{
+  "instance": {
+    "latestVersion": "2.0.0",
+    "latestUrl": "https://updates.example.com/Updater.exe",
+    "latestChecksum": {
+      "checksum": "<sha256-hex-of-Updater.exe>",
+      "checksumAlg": "SHA256"
+    }
+  }
+}
+```
+
+---
+
+## Layer 5 — URL scheme enforcement
+
+`downloadUrl` and `latestUrl` must use `https://`.  Plain `http://`, `file://`,
+and any other scheme are rejected.  In debug builds (`!NDEBUG`), HTTP to localhost
+(`127.0.0.1`, `[::1]`) is permitted for local test servers.
+
+---
+
+## Strict mode CLI flag
+
+Pass `--strict-verification` to the updater binary to enable strict mode globally:
+
+- Checksum absent → reject (instead of warn-and-allow).
+- Authenticode mode upgraded from `WhenPresent` to `Required`.
+- Comparison policy upgraded from `Relaxed` to `Strict`.
+
+---
+
+## Example manifest
+
+See `examples/configs/example_secure_updates.json` for a fully-annotated example
+that demonstrates all layers.

--- a/examples/configs/example_secure_updates.json
+++ b/examples/configs/example_secure_updates.json
@@ -1,0 +1,73 @@
+{
+  "$comment": "Example vicius updates.json with full security hardening (Layer 1-5 from the Secure Update Pipeline plan).",
+
+  "shared": {
+    "windowTitle": "My Product Updater",
+    "productName": "My Product",
+
+    "detectionMethod": "RegistryValue",
+    "detection": {
+      "hive": "HKLM",
+      "key": "Software\\MyCompany\\MyProduct",
+      "valueName": "Version",
+      "statement": "SemverRange",
+      "data": {}
+    },
+
+    "$comment_signature": "Global Authenticode verification settings.",
+    "signatureVerificationMode": "Required",
+    "signaturePolicy": "Strict",
+    "signatureStrategy": "FromConfiguration",
+    "signatureConfig": {
+      "$comment": "Pin by subject name (stable across cert renewals). Add serialNumber/thumbprint only if you also rotate them here on each renewal.",
+      "subjectName": "My Company, Inc.",
+      "issuerName": "DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1"
+    }
+  },
+
+  "$comment_instance": "Self-updater binary information (Layer 4). latestChecksum is passed to the self-updater DLL for verification before swap.",
+  "instance": {
+    "latestVersion": "2.0.0",
+    "latestUrl": "https://updates.example.com/MyProduct/Updater.exe",
+    "latestChecksum": {
+      "checksum": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+      "checksumAlg": "SHA256"
+    }
+  },
+
+  "$comment_manifest_version": "Rollback protection: increase this monotonically on every manifest publish. Deployed clients reject manifests with a lower version than the last seen.",
+  "manifestVersion": 42,
+
+  "releases": [
+    {
+      "name": "My Product 1.2.3",
+      "version": "1.2.3",
+      "summary": "# Release Notes\n\nSecurity and stability improvements.",
+      "publishedAt": "2026-06-01T12:00:00Z",
+
+      "$comment_download": "Layer 5: HTTPS only (http:// and file:// are rejected by the updater).",
+      "downloadUrl": "https://updates.example.com/MyProduct/setup-1.2.3.exe",
+
+      "$comment_checksum": "Layer 1: SHA-256 checksum of the setup file (hex). Must match before execution.",
+      "checksum": {
+        "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "checksumAlg": "SHA256"
+      },
+
+      "$comment_signature": "Layer 2/3: Per-release cert pin (FromConfiguration). These values travel inside the signed manifest so rotating them on cert renewal is safe.",
+      "signatureStrategy": "FromConfiguration",
+      "signaturePolicy": "Strict",
+      "signature": {
+        "subjectName": "My Company, Inc.",
+        "issuerName": "DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1",
+        "$comment_volatile": "Add serialNumber/thumbprintSha256 here only when you want extra-strict pinning AND you will update this manifest before switching certs.",
+        "serialNumber": "0a:1b:2c:3d:4e:5f",
+        "thumbprintSha256": "deadbeef0000000000000000000000000000000000000000000000000000beef"
+      },
+
+      "exitCode": {
+        "successCodes": [0, 3010]
+      }
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,14 @@ find_package(directxtk CONFIG REQUIRED)
 # vcpkg port of neflib does not define a target
 find_library(NEFLIB_PATH NAMES neflib REQUIRED)
 
+# Optional: manifest Ed25519 signing (only linked when NV_MANIFEST_PUBLIC_KEY is defined)
+find_package(unofficial-sodium CONFIG)
+if(unofficial-sodium_FOUND)
+  message(STATUS "libsodium found - manifest signature verification available")
+else()
+  message(STATUS "libsodium NOT found - manifest signature verification disabled (add libsodium to vcpkg.json to enable)")
+endif()
+
 # Header files don't *need* to be specified, but it helps some IDEs
 add_executable(
   Updater
@@ -16,6 +24,7 @@ add_executable(
   InstanceConfig.Dialogs.cpp
   InstanceConfig.Download.cpp
   InstanceConfig.Postpone.cpp
+  InstanceConfig.Security.cpp
   InstanceConfig.Setup.cpp
   InstanceConfig.TaskScheduler.cpp
   InstanceConfig.Template.cpp
@@ -70,7 +79,13 @@ target_link_libraries(
   taskschd
   Version
   runtimeobject
+  wintrust
 )
+
+# Link libsodium when available (needed for manifest Ed25519 signature verification)
+if(unofficial-sodium_FOUND)
+  target_link_libraries(Updater PRIVATE unofficial-sodium::sodium)
+endif()
 
 # We *should* be able to directly add vicius.rc to the executable sources,
 # and CMake *should* build self-updater first when it sees it's a dependency

--- a/src/Common.h
+++ b/src/Common.h
@@ -30,6 +30,8 @@
 #define NV_CLI_PARAM_FORCE_LOCAL_VERSION             "--force-local-version"
 // internal
 #define NV_CLI_TEMPORARY                             "--temporary"
+/** Enable strict verification: checksum required, Authenticode required, pin must match */
+#define NV_CLI_STRICT_VERIFICATION                   "--strict-verification"
 
 //
 // App exit codes
@@ -53,6 +55,11 @@
 #define NV_E_INVALID_PARAMETERS                      112
 #define NV_E_INVALID_MODULE_NAME                     113
 #define NV_E_CREATE_D3D_DEVICE                       114
+#define NV_E_CHECKSUM_MISMATCH                       115
+#define NV_E_SIGNATURE_INVALID                       116
+#define NV_E_PUBLISHER_MISMATCH                      117
+#define NV_E_MANIFEST_SIGNATURE_INVALID              118
+#define NV_E_MANIFEST_DOWNGRADE                      119
 
 //
 // Success codes

--- a/src/CustomizeMe.h
+++ b/src/CustomizeMe.h
@@ -73,6 +73,22 @@
 
 
 /*
+ * Manifest signing (Ed25519 / minisign-compatible)
+ *
+ * Set NV_MANIFEST_PUBLIC_KEY to your minisign public-key string (the second line of the
+ * .pub file, base64-encoded, starting with "RWSA...") to enable per-manifest signature
+ * verification.  When defined, verification is mandatory; when absent, verification is
+ * skipped (backward-compatible for unsigned deployments).
+ *
+ * Generate a keypair:    minisign -G
+ * Sign your manifest:    minisign -S -s ~/.minisign/minisign.key -m updates.json
+ *   (produces updates.json.minisig alongside updates.json)
+ *
+ * Rotate on cert renewal: sign a new manifest with the SAME Ed25519 key; no redeploy needed.
+ */
+// #define NV_MANIFEST_PUBLIC_KEY  "RWSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+/*
  * Compiler switches turning optional features on or off
  */
 

--- a/src/DownloadAndInstall.hpp
+++ b/src/DownloadAndInstall.hpp
@@ -6,6 +6,8 @@ enum class DownloadAndInstallStep
     Downloading,
     DownloadFailed,
     DownloadSucceeded,
+    Verifying,
+    VerificationFailed,
     PrepareInstall,
     InstallRunning,
     InstallFailed,

--- a/src/InstanceConfig.Security.cpp
+++ b/src/InstanceConfig.Security.cpp
@@ -1,0 +1,635 @@
+#include "pch.h"
+#include "Util.h"
+#include "InstanceConfig.hpp"
+#include "NAuthenticode.h"
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+namespace
+{
+    /**
+     * \brief Hash a file with MD5 and return the hex digest.
+     */
+    std::string HashFileMD5(const std::string& filePath)
+    {
+        MD5 alg;
+        std::ifstream file(filePath, std::ios::binary);
+        if (!file.is_open()) return {};
+
+        constexpr std::size_t chunkSize = 4 * 1024;
+        std::vector<char> buf(chunkSize);
+        while (!file.eof())
+        {
+            file.read(buf.data(), buf.size());
+            const std::streamsize n = file.gcount();
+            if (n > 0) alg.add(buf.data(), n);
+        }
+        return alg.getHash();
+    }
+
+    std::string HashFileSHA1(const std::string& filePath)
+    {
+        SHA1 alg;
+        std::ifstream file(filePath, std::ios::binary);
+        if (!file.is_open()) return {};
+
+        constexpr std::size_t chunkSize = 4 * 1024;
+        std::vector<char> buf(chunkSize);
+        while (!file.eof())
+        {
+            file.read(buf.data(), buf.size());
+            const std::streamsize n = file.gcount();
+            if (n > 0) alg.add(buf.data(), n);
+        }
+        return alg.getHash();
+    }
+
+    std::string HashFileSHA256(const std::string& filePath)
+    {
+        SHA256 alg;
+        std::ifstream file(filePath, std::ios::binary);
+        if (!file.is_open()) return {};
+
+        constexpr std::size_t chunkSize = 4 * 1024;
+        std::vector<char> buf(chunkSize);
+        while (!file.eof())
+        {
+            file.read(buf.data(), buf.size());
+            const std::streamsize n = file.gcount();
+            if (n > 0) alg.add(buf.data(), n);
+        }
+        return alg.getHash();
+    }
+
+    /**
+     * \brief Convert a LPCWSTR (may be nullptr) to a UTF-8 std::string for comparison.
+     *        Works for both LPWSTR and LPTSTR (which = LPWSTR when CharacterSet=Unicode).
+     */
+    std::string WstrToUtf8(LPCWSTR p)
+    {
+        if (!p) return {};
+        const int len = WideCharToMultiByte(CP_UTF8, 0, p, -1, nullptr, 0, nullptr, nullptr);
+        if (len <= 0) return {};
+        std::string result(len - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, p, -1, result.data(), len, nullptr, nullptr);
+        return result;
+    }
+
+    /**
+     * \brief Match a pin value (optional) against an actual cert field.
+     *        If the pin is absent, the field is considered a match (not pinned).
+     */
+    bool PinMatches(const std::optional<std::string>& pin, const std::string& actual)
+    {
+        if (!pin.has_value()) return true;           // not pinned, always OK
+        if (pin.value().empty()) return true;         // empty pin treated as not set
+        return util::icompare(pin.value(), actual);   // case-insensitive compare
+    }
+
+    /**
+     * \brief Compute the SHA-1 thumbprint of a certificate context and return hex string.
+     */
+    std::string CertThumbprintSha1(PCCERT_CONTEXT ctx)
+    {
+        if (!ctx) return {};
+        BYTE hash[20] = {};
+        DWORD hashLen = sizeof(hash);
+        if (!CertGetCertificateContextProperty(ctx, CERT_SHA1_HASH_PROP_ID, hash, &hashLen)) return {};
+
+        std::string result;
+        result.reserve(hashLen * 2);
+        for (DWORD i = 0; i < hashLen; ++i)
+        {
+            char buf[3];
+            std::snprintf(buf, sizeof(buf), "%02x", hash[i]);
+            result += buf;
+        }
+        return result;
+    }
+
+    /**
+     * \brief Compute the SHA-256 thumbprint of a certificate context and return hex string.
+     */
+    std::string CertThumbprintSha256(PCCERT_CONTEXT ctx)
+    {
+        if (!ctx) return {};
+        BYTE hash[32] = {};
+        DWORD hashLen = sizeof(hash);
+        if (!CertGetCertificateContextProperty(ctx, CERT_SHA256_HASH_PROP_ID, hash, &hashLen)) return {};
+
+        std::string result;
+        result.reserve(hashLen * 2);
+        for (DWORD i = 0; i < hashLen; ++i)
+        {
+            char buf[3];
+            std::snprintf(buf, sizeof(buf), "%02x", hash[i]);
+            result += buf;
+        }
+        return result;
+    }
+
+    /**
+     * \brief Look up the leaf signing certificate from the given file and invoke a callback.
+     *        Returns false if the file is not signed or the cert can't be located.
+     */
+    bool WithSigningCert(const std::filesystem::path& filePath,
+                         const std::function<void(PCCERT_CONTEXT)>& callback)
+    {
+        HCERTSTORE hStore = nullptr;
+        HCRYPTMSG hMsg = nullptr;
+        DWORD dwEncoding = 0, dwContentType = 0, dwFormatType = 0;
+
+        const auto wPath = filePath.wstring();
+        const BOOL ok = CryptQueryObject(
+            CERT_QUERY_OBJECT_FILE,
+            wPath.c_str(),
+            CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
+            CERT_QUERY_FORMAT_FLAG_BINARY,
+            0,
+            &dwEncoding, &dwContentType, &dwFormatType,
+            &hStore, &hMsg, nullptr
+        );
+
+        if (!ok) return false;
+
+        auto cleanupScope = sg::make_scope_guard([&]
+        {
+            if (hMsg) CryptMsgClose(hMsg);
+            if (hStore) CertCloseStore(hStore, 0);
+        });
+
+        DWORD dwSignerInfo = 0;
+        if (!CryptMsgGetParam(hMsg, CMSG_SIGNER_INFO_PARAM, 0, nullptr, &dwSignerInfo) || dwSignerInfo == 0)
+            return false;
+
+        std::vector<BYTE> signerBuf(dwSignerInfo);
+        if (!CryptMsgGetParam(hMsg, CMSG_SIGNER_INFO_PARAM, 0, signerBuf.data(), &dwSignerInfo))
+            return false;
+
+        const auto* pSignerInfo = reinterpret_cast<PCMSG_SIGNER_INFO>(signerBuf.data());
+
+        CERT_INFO ci = {};
+        ci.Issuer = pSignerInfo->Issuer;
+        ci.SerialNumber = pSignerInfo->SerialNumber;
+
+        PCCERT_CONTEXT pCertCtx = CertFindCertificateInStore(
+            hStore, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0,
+            CERT_FIND_SUBJECT_CERT, &ci, nullptr);
+
+        if (!pCertCtx) return false;
+
+        auto certScope = sg::make_scope_guard([pCertCtx] { CertFreeCertificateContext(pCertCtx); });
+        callback(pCertCtx);
+        return true;
+    }
+
+} // namespace
+
+// ============================================================================
+// Layer 1: Setup Checksum Verification
+// ============================================================================
+
+std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
+{
+    const auto& release = GetSelectedRelease();
+    const auto tempFile = GetLocalReleaseTempFilePath(GetSelectedReleaseId());
+
+    spdlog::debug("VerifyReleaseIntegrity: verifying {}", tempFile.string());
+
+    //
+    // --- Checksum layer ---
+    //
+    if (release.checksum.has_value())
+    {
+        const auto& hashCfg = release.checksum.value();
+
+        if (!std::filesystem::exists(tempFile))
+        {
+            spdlog::error("Checksum verification: downloaded file not found at {}", tempFile.string());
+            return {false, "Downloaded file not found for checksum verification"};
+        }
+
+        std::string computed;
+        switch (hashCfg.checksumAlg)
+        {
+            case ChecksumAlgorithm::MD5:
+                spdlog::debug("Checksum verification: hashing with MD5");
+                computed = HashFileMD5(tempFile.string());
+                break;
+            case ChecksumAlgorithm::SHA1:
+                spdlog::debug("Checksum verification: hashing with SHA1");
+                computed = HashFileSHA1(tempFile.string());
+                break;
+            case ChecksumAlgorithm::SHA256:
+                spdlog::debug("Checksum verification: hashing with SHA256");
+                computed = HashFileSHA256(tempFile.string());
+                break;
+            case ChecksumAlgorithm::Invalid:
+                spdlog::error("Checksum verification: invalid algorithm specified in manifest");
+                return {false, "Invalid checksum algorithm specified in manifest"};
+        }
+
+        if (computed.empty())
+        {
+            spdlog::error("Checksum verification: failed to hash file {}", tempFile.string());
+            return {false, "Failed to compute file checksum"};
+        }
+
+        spdlog::debug("Checksum verification: computed={}, expected={}", computed, hashCfg.checksum);
+
+        if (!util::icompare(computed, hashCfg.checksum))
+        {
+            spdlog::error("Checksum verification FAILED: computed {} does not match expected {}",
+                          computed, hashCfg.checksum);
+            return {false, std::format("Checksum mismatch: expected {}, got {}", hashCfg.checksum, computed)};
+        }
+
+        spdlog::info("Checksum verification passed");
+    }
+    else
+    {
+        if (strictVerification)
+        {
+            spdlog::error("Checksum verification: no checksum in manifest and strict mode is active");
+            return {false, "No checksum provided by the update server and strict verification is enabled"};
+        }
+        spdlog::warn("Checksum verification: no checksum provided, skipping (relaxed mode)");
+    }
+
+    //
+    // --- Authenticode / publisher pin layer ---
+    //
+    const auto verificationMode = merged.signatureVerificationMode;
+
+    if (verificationMode == SignatureVerificationMode::Disabled)
+    {
+        spdlog::info("Authenticode verification is disabled by configuration");
+        return {true, "OK"};
+    }
+
+    // Resolve effective policy and strategy (release-level overrides global)
+    const auto effectivePolicy = release.signaturePolicy.value_or(merged.signaturePolicy);
+    const auto effectiveStrategy = release.signatureStrategy.value_or(merged.signatureStrategy);
+
+    // Release-level signature config takes precedence (implies FromConfiguration)
+    const auto& effectiveSigConfig = release.signature.has_value()
+                                         ? release.signature
+                                         : merged.signatureConfig;
+
+    const auto [sigOk, sigReason] = VerifySetupSignature(tempFile, effectiveSigConfig, effectivePolicy, effectiveStrategy);
+
+    if (!sigOk)
+    {
+        // If the file is unsigned and we are in WhenPresent mode, accept it
+        if (verificationMode == SignatureVerificationMode::WhenPresent &&
+            sigReason.find("not signed") != std::string::npos)
+        {
+            spdlog::warn("Authenticode verification: file is unsigned, accepting (WhenPresent mode)");
+            return {true, "OK"};
+        }
+        return {false, sigReason};
+    }
+
+    return {true, "OK"};
+}
+
+// ============================================================================
+// Layer 2 + 3: Authenticode Verification + Publisher Pinning
+// ============================================================================
+
+std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
+    const std::filesystem::path& filePath,
+    const std::optional<models::SignatureConfig>& releaseSig,
+    models::SignatureComparisonPolicy policy,
+    models::SignatureVerificationStrategy strategy) const
+{
+    spdlog::debug("VerifySetupSignature: checking {}", filePath.string());
+
+    // Run WinVerifyTrust (chain validation + revocation, no lifetime-signing flag).
+    // NVerifyFileSignature takes LPCTSTR which is LPCWSTR when CharacterSet=Unicode.
+    NSIGINFO sigInfo = {};
+    const BOOL chainOk = NVerifyFileSignature(filePath.wstring().c_str(), &sigInfo);
+
+    auto cleanupScope = sg::make_scope_guard([&sigInfo] { NCertFreeSigInfo(&sigInfo); });
+
+    if (!chainOk)
+    {
+        if (sigInfo.lValidationResult == TRUST_E_NOSIGNATURE)
+        {
+            spdlog::warn("VerifySetupSignature: file is not signed: {}", filePath.string());
+            return {false, "File is not signed"};
+        }
+
+        const LONG result = sigInfo.lValidationResult;
+        spdlog::error("VerifySetupSignature: WinVerifyTrust failed with {:#x} for {}", result, filePath.string());
+        return {false, std::format("Authenticode chain validation failed ({:#x})", static_cast<unsigned long>(result))};
+    }
+
+    spdlog::info("VerifySetupSignature: Authenticode chain valid for {}", filePath.string());
+
+    // Relaxed with no configuration = chain valid is enough
+    if (policy == SignatureComparisonPolicy::Relaxed && !releaseSig.has_value() &&
+        strategy == SignatureVerificationStrategy::FromUpdaterBinary && !isUpdaterSigned)
+    {
+        spdlog::info("VerifySetupSignature: relaxed mode, no pin configured - accepting");
+        return {true, "OK"};
+    }
+
+    // Extract cert info from the downloaded file for pinning
+    crypto::SIGNATURE_INFORMATION fileInfo = {};
+    const bool extracted = crypto::ExtractSignatureInformation(filePath.wstring().c_str(), &fileInfo);
+
+    auto certCleanup = sg::make_scope_guard([&fileInfo]
+    {
+        crypto::FreeSignatureInformation(&fileInfo);
+    });
+
+    if (!extracted)
+    {
+        // Can't extract but chain was valid - only fail in Strict mode
+        if (policy == SignatureComparisonPolicy::Strict)
+        {
+            spdlog::error("VerifySetupSignature: could not extract cert info for pinning in strict mode");
+            return {false, "Could not extract certificate information for publisher pin verification"};
+        }
+        spdlog::warn("VerifySetupSignature: could not extract cert info, relaxed mode - accepting");
+        return {true, "OK"};
+    }
+
+    const std::string fileSubject  = WstrToUtf8(fileInfo.SubjectName);
+    const std::string fileIssuer   = WstrToUtf8(fileInfo.IssuerName);
+    const std::string fileSerial   = WstrToUtf8(fileInfo.SerialNumber);
+
+    spdlog::debug("VerifySetupSignature: file subject='{}' issuer='{}' serial='{}'",
+                  fileSubject, fileIssuer, fileSerial);
+
+    // Determine the effective pin source
+    const bool hasReleaseSig = releaseSig.has_value();
+    const bool useFromConfig = hasReleaseSig ||
+                               strategy == SignatureVerificationStrategy::FromConfiguration;
+
+    if (useFromConfig && releaseSig.has_value())
+    {
+        // FromConfiguration: compare against explicit cert pin from (signed) manifest
+        const auto& pin = releaseSig.value();
+
+        // Build thumbprints on demand for comparison
+        std::string fileSha1, fileSha256;
+        if (pin.thumbprintSha1.has_value() || pin.thumbprintSha256.has_value())
+        {
+            WithSigningCert(filePath, [&](PCCERT_CONTEXT ctx)
+            {
+                if (pin.thumbprintSha1.has_value()) fileSha1 = CertThumbprintSha1(ctx);
+                if (pin.thumbprintSha256.has_value()) fileSha256 = CertThumbprintSha256(ctx);
+            });
+        }
+
+        bool pinMatch = PinMatches(pin.subjectName, fileSubject)
+                     && PinMatches(pin.issuerName,  fileIssuer)
+                     && PinMatches(pin.serialNumber, fileSerial)
+                     && PinMatches(pin.thumbprintSha1,   fileSha1)
+                     && PinMatches(pin.thumbprintSha256,  fileSha256);
+
+        if (!pinMatch)
+        {
+            spdlog::error("VerifySetupSignature: publisher pin mismatch (FromConfiguration)");
+            spdlog::debug("  file  subject='{}' issuer='{}' serial='{}' sha1='{}' sha256='{}'",
+                          fileSubject, fileIssuer, fileSerial, fileSha1, fileSha256);
+            spdlog::debug("  pin   subject='{}' issuer='{}' serial='{}' sha1='{}' sha256='{}'",
+                          pin.subjectName.value_or("<any>"),
+                          pin.issuerName.value_or("<any>"),
+                          pin.serialNumber.value_or("<any>"),
+                          pin.thumbprintSha1.value_or("<any>"),
+                          pin.thumbprintSha256.value_or("<any>"));
+            return {false, "Publisher certificate does not match the configured pin"};
+        }
+
+        spdlog::info("VerifySetupSignature: publisher pin matched (FromConfiguration)");
+        return {true, "OK"};
+    }
+
+    if (strategy == SignatureVerificationStrategy::FromUpdaterBinary && isUpdaterSigned)
+    {
+        // FromUpdaterBinary: compare subjectName ONLY (stable across cert renewals).
+        // Use the extended cert info (appCertInfo.SubjectName) rather than the WinTrust
+        // publisher string (appSigInfo.lpszPublisher) for a consistent field.
+        const std::string updaterSubject = WstrToUtf8(appCertInfo.SubjectName);
+
+        spdlog::debug("VerifySetupSignature: FromUpdaterBinary: updater subject='{}' file subject='{}'",
+                      updaterSubject, fileSubject);
+
+        if (!util::icompare(updaterSubject, fileSubject))
+        {
+            spdlog::error("VerifySetupSignature: publisher mismatch (FromUpdaterBinary): "
+                          "updater='{}' setup='{}'", updaterSubject, fileSubject);
+            return {false, std::format(
+                "Setup publisher ('{}') does not match updater publisher ('{}').",
+                fileSubject, updaterSubject)};
+        }
+
+        spdlog::info("VerifySetupSignature: publisher matched (FromUpdaterBinary, subjectName)");
+        return {true, "OK"};
+    }
+
+    // No pin configured and Relaxed policy - chain valid is sufficient
+    spdlog::info("VerifySetupSignature: no publisher pin configured, accepting (chain valid)");
+    return {true, "OK"};
+}
+
+// ============================================================================
+// Layer 4 (manifest): Ed25519 / minisign signature verification
+// ============================================================================
+
+#if defined(NV_MANIFEST_PUBLIC_KEY)
+
+/**
+ * \brief Parse a minisign .minisig file and extract the raw Ed25519 signature bytes.
+ *
+ * The minisign .minisig format is:
+ *   Line 0: comment ("untrusted comment: ...")
+ *   Line 1: base64-encoded  "signature_algorithm (2 bytes) || key_id (8 bytes) || signature (64 bytes)"
+ *   Line 2: trusted comment ("trusted comment: ...")
+ *   Line 3: base64-encoded global signature (covers trusted comment + file signature)
+ *
+ * We only need line 1 to verify the file body.
+ */
+static bool ParseMinisigFile(const std::string& minisigBody,
+                             std::string& outKeyId,
+                             std::vector<unsigned char>& outSig)
+{
+    // Split into lines
+    std::vector<std::string> lines;
+    std::istringstream ss(minisigBody);
+    std::string line;
+    while (std::getline(ss, line))
+    {
+        // Strip CR
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        if (!line.empty()) lines.push_back(line);
+    }
+
+    if (lines.size() < 2) return false;
+
+    // Decode line 1 (base64)
+    const auto& b64 = lines[1];
+    const auto decodedLen = static_cast<size_t>(sodium_base642bin_MAXLEN(b64.size()));
+    std::vector<unsigned char> decoded(decodedLen);
+    size_t actualLen = 0;
+
+    if (sodium_base642bin(decoded.data(), decodedLen, b64.c_str(), b64.size(),
+                          nullptr, &actualLen, nullptr, sodium_base64_VARIANT_ORIGINAL) != 0)
+    {
+        return false;
+    }
+
+    // Layout: 2 bytes algo + 8 bytes key id + 64 bytes Ed25519 sig = 74 bytes total
+    if (actualLen < 74) return false;
+
+    // First 2 bytes: algorithm ("Ed" for Ed25519)
+    if (decoded[0] != 'E' || decoded[1] != 'd') return false;
+
+    // Bytes 2-9: key id (we store as hex string for logging)
+    std::string keyId;
+    keyId.reserve(16);
+    for (int i = 2; i < 10; ++i)
+    {
+        char buf[3];
+        std::snprintf(buf, sizeof(buf), "%02x", decoded[i]);
+        keyId += buf;
+    }
+    outKeyId = keyId;
+
+    // Bytes 10-73: Ed25519 signature
+    outSig.assign(decoded.begin() + 10, decoded.begin() + 10 + crypto_sign_BYTES);
+    return true;
+}
+
+/**
+ * \brief Decode the base64 public key from the NV_MANIFEST_PUBLIC_KEY string.
+ *        The key string is the second line of a minisign .pub file.
+ *        Layout: 2 bytes algo + 8 bytes key id + 32 bytes public key = 42 bytes.
+ */
+static bool ParseMinisignPublicKey(const char* pubKeyStr,
+                                   std::vector<unsigned char>& outPubKey)
+{
+    const size_t maxLen = sodium_base642bin_MAXLEN(strlen(pubKeyStr));
+    std::vector<unsigned char> decoded(maxLen);
+    size_t actualLen = 0;
+
+    if (sodium_base642bin(decoded.data(), maxLen, pubKeyStr, strlen(pubKeyStr),
+                          nullptr, &actualLen, nullptr, sodium_base64_VARIANT_ORIGINAL) != 0)
+    {
+        return false;
+    }
+
+    if (actualLen < 42) return false;                    // 2 + 8 + 32
+    if (decoded[0] != 'E' || decoded[1] != 'd') return false;
+
+    outPubKey.assign(decoded.begin() + 10, decoded.begin() + 10 + crypto_sign_PUBLICKEYBYTES);
+    return true;
+}
+
+std::tuple<bool, std::string> models::InstanceConfig::VerifyManifestSignature(
+    const std::string& manifestBody,
+    const std::string& minisigBody)
+{
+    if (sodium_init() < 0)
+    {
+        return {false, "Failed to initialize libsodium"};
+    }
+
+    // Parse the .minisig sidecar
+    std::string keyId;
+    std::vector<unsigned char> sig;
+    if (!ParseMinisigFile(minisigBody, keyId, sig))
+    {
+        return {false, "Failed to parse manifest signature file (.minisig)"};
+    }
+
+    spdlog::debug("VerifyManifestSignature: key id from .minisig = {}", keyId);
+
+    if (sig.size() != crypto_sign_BYTES)
+    {
+        return {false, std::format("Invalid signature length: expected {}, got {}", crypto_sign_BYTES, sig.size())};
+    }
+
+    // Decode the compiled-in public key
+    std::vector<unsigned char> pubKey;
+    if (!ParseMinisignPublicKey(NV_MANIFEST_PUBLIC_KEY, pubKey))
+    {
+        return {false, "Failed to decode the compiled-in manifest public key (NV_MANIFEST_PUBLIC_KEY)"};
+    }
+
+    if (pubKey.size() != crypto_sign_PUBLICKEYBYTES)
+    {
+        return {false, "Invalid compiled-in public key length"};
+    }
+
+    // Verify signature over raw manifest bytes
+    const int result = crypto_sign_verify_detached(
+        sig.data(),
+        reinterpret_cast<const unsigned char*>(manifestBody.data()),
+        manifestBody.size(),
+        pubKey.data()
+    );
+
+    if (result != 0)
+    {
+        spdlog::error("VerifyManifestSignature: Ed25519 signature verification FAILED");
+        return {false, "Manifest signature is invalid - the update manifest may have been tampered with"};
+    }
+
+    spdlog::info("VerifyManifestSignature: manifest signature valid");
+    return {true, "OK"};
+}
+
+bool models::InstanceConfig::CheckAndUpdateManifestVersion(const uint64_t signedVersion) const
+{
+    //
+    // Persist the highest manifest version seen in a volatile registry key.
+    // Key: HKCU\Software\<manufacturer>\<product>\Vicius\ManifestVersion
+    //
+    const auto subKey = std::format(L"Software\\{}\\{}\\Vicius",
+                                    ConvertAnsiToWide(manufacturer.empty() ? appFilename : manufacturer),
+                                    ConvertAnsiToWide(product.empty() ? appFilename : product));
+
+    winreg::RegKey key;
+    constexpr REGSAM flags = KEY_READ | KEY_WRITE;
+
+    if (const auto result = key.TryCreate(HKEY_CURRENT_USER, subKey, flags); !result)
+    {
+        spdlog::warn("CheckAndUpdateManifestVersion: could not open/create registry key ({})", result.Code());
+        return true; // non-fatal; don't block updates over a registry hiccup
+    }
+
+    constexpr auto valueName = L"ManifestVersion";
+    uint64_t stored = 0;
+
+    if (const auto readResult = key.TryGetQwordValue(valueName); readResult)
+    {
+        stored = readResult.GetValue();
+    }
+
+    spdlog::debug("CheckAndUpdateManifestVersion: stored={} signed={}", stored, signedVersion);
+
+    if (signedVersion < stored)
+    {
+        spdlog::error("CheckAndUpdateManifestVersion: rollback detected! signed={} < stored={}",
+                      signedVersion, stored);
+        return false;
+    }
+
+    if (signedVersion > stored)
+    {
+        if (const auto writeResult = key.TrySetQwordValue(valueName, signedVersion); !writeResult)
+        {
+            spdlog::warn("CheckAndUpdateManifestVersion: could not persist version ({})", writeResult.Code());
+        }
+    }
+
+    return true;
+}
+
+#endif // NV_MANIFEST_PUBLIC_KEY

--- a/src/InstanceConfig.Security.cpp
+++ b/src/InstanceConfig.Security.cpp
@@ -432,8 +432,21 @@ std::expected<void, std::string> models::InstanceConfig::VerifySetupSignature(
         return {};
     }
 
-    // No pin configured and Relaxed policy - chain valid is sufficient
-    spdlog::info("VerifySetupSignature: no publisher pin configured, accepting (chain valid)");
+    // Reached here because the requested pin source could not be resolved:
+    //   - FromConfiguration was requested but no SignatureConfig is present, OR
+    //   - FromUpdaterBinary was requested but the updater binary itself is not signed.
+    // The Relaxed+FromUpdaterBinary+!isUpdaterSigned case was already accepted above (line 332-338).
+    // In Strict mode we must fail closed; accepting on chain-only would defeat the pin requirement.
+    if (policy == SignatureComparisonPolicy::Strict)
+    {
+        spdlog::error("VerifySetupSignature: strict mode requires a resolvable publisher pin "
+                      "(strategy={}, isUpdaterSigned={}), but none is available - rejecting",
+                      magic_enum::enum_name(strategy), isUpdaterSigned);
+        return std::unexpected("Strict verification requires a publisher pin but none could be resolved "
+                               "(check signatureStrategy / signatureConfig settings)");
+    }
+
+    spdlog::info("VerifySetupSignature: no publisher pin resolvable, accepting on chain validity (relaxed mode)");
     return {};
 }
 

--- a/src/InstanceConfig.Security.cpp
+++ b/src/InstanceConfig.Security.cpp
@@ -191,7 +191,7 @@ namespace
 // Layer 1: Setup Checksum Verification
 // ============================================================================
 
-std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
+std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
 {
     const auto& release = GetSelectedRelease();
     const auto tempFile = GetLocalReleaseTempFilePath(GetSelectedReleaseId());
@@ -208,7 +208,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
         if (!std::filesystem::exists(tempFile))
         {
             spdlog::error("Checksum verification: downloaded file not found at {}", tempFile.string());
-            return {false, "Downloaded file not found for checksum verification"};
+            return std::unexpected("Downloaded file not found for checksum verification");
         }
 
         std::string computed;
@@ -228,13 +228,13 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
                 break;
             case ChecksumAlgorithm::Invalid:
                 spdlog::error("Checksum verification: invalid algorithm specified in manifest");
-                return {false, "Invalid checksum algorithm specified in manifest"};
+                return std::unexpected("Invalid checksum algorithm specified in manifest");
         }
 
         if (computed.empty())
         {
             spdlog::error("Checksum verification: failed to hash file {}", tempFile.string());
-            return {false, "Failed to compute file checksum"};
+            return std::unexpected("Failed to compute file checksum");
         }
 
         spdlog::debug("Checksum verification: computed={}, expected={}", computed, hashCfg.checksum);
@@ -243,7 +243,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
         {
             spdlog::error("Checksum verification FAILED: computed {} does not match expected {}",
                           computed, hashCfg.checksum);
-            return {false, std::format("Checksum mismatch: expected {}, got {}", hashCfg.checksum, computed)};
+            return std::unexpected(std::format("Checksum mismatch: expected {}, got {}", hashCfg.checksum, computed));
         }
 
         spdlog::info("Checksum verification passed");
@@ -253,7 +253,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
         if (strictVerification)
         {
             spdlog::error("Checksum verification: no checksum in manifest and strict mode is active");
-            return {false, "No checksum provided by the update server and strict verification is enabled"};
+            return std::unexpected("No checksum provided by the update server and strict verification is enabled");
         }
         spdlog::warn("Checksum verification: no checksum provided, skipping (relaxed mode)");
     }
@@ -266,7 +266,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
     if (verificationMode == SignatureVerificationMode::Disabled)
     {
         spdlog::info("Authenticode verification is disabled by configuration");
-        return {true, "OK"};
+        return {};
     }
 
     // Resolve effective policy and strategy (release-level overrides global)
@@ -278,28 +278,28 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
                                          ? release.signature
                                          : merged.signatureConfig;
 
-    const auto [sigOk, sigReason] = VerifySetupSignature(tempFile, effectiveSigConfig, effectivePolicy, effectiveStrategy);
+    const auto sigResult = VerifySetupSignature(tempFile, effectiveSigConfig, effectivePolicy, effectiveStrategy);
 
-    if (!sigOk)
+    if (!sigResult)
     {
         // If the file is unsigned and we are in WhenPresent mode, accept it
         if (verificationMode == SignatureVerificationMode::WhenPresent &&
-            sigReason.find("not signed") != std::string::npos)
+            sigResult.error().find("not signed") != std::string::npos)
         {
             spdlog::warn("Authenticode verification: file is unsigned, accepting (WhenPresent mode)");
-            return {true, "OK"};
+            return {};
         }
-        return {false, sigReason};
+        return std::unexpected(sigResult.error());
     }
 
-    return {true, "OK"};
+    return {};
 }
 
 // ============================================================================
 // Layer 2 + 3: Authenticode Verification + Publisher Pinning
 // ============================================================================
 
-std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
+std::expected<void, std::string> models::InstanceConfig::VerifySetupSignature(
     const std::filesystem::path& filePath,
     const std::optional<models::SignatureConfig>& releaseSig,
     models::SignatureComparisonPolicy policy,
@@ -319,12 +319,12 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
         if (sigInfo.lValidationResult == TRUST_E_NOSIGNATURE)
         {
             spdlog::warn("VerifySetupSignature: file is not signed: {}", filePath.string());
-            return {false, "File is not signed"};
+            return std::unexpected(std::string("File is not signed"));
         }
 
         const LONG result = sigInfo.lValidationResult;
         spdlog::error("VerifySetupSignature: WinVerifyTrust failed with {:#x} for {}", result, filePath.string());
-        return {false, std::format("Authenticode chain validation failed ({:#x})", static_cast<unsigned long>(result))};
+        return std::unexpected(std::format("Authenticode chain validation failed ({:#x})", static_cast<unsigned long>(result)));
     }
 
     spdlog::info("VerifySetupSignature: Authenticode chain valid for {}", filePath.string());
@@ -334,7 +334,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
         strategy == SignatureVerificationStrategy::FromUpdaterBinary && !isUpdaterSigned)
     {
         spdlog::info("VerifySetupSignature: relaxed mode, no pin configured - accepting");
-        return {true, "OK"};
+        return {};
     }
 
     // Extract cert info from the downloaded file for pinning
@@ -352,10 +352,10 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
         if (policy == SignatureComparisonPolicy::Strict)
         {
             spdlog::error("VerifySetupSignature: could not extract cert info for pinning in strict mode");
-            return {false, "Could not extract certificate information for publisher pin verification"};
+            return std::unexpected("Could not extract certificate information for publisher pin verification");
         }
         spdlog::warn("VerifySetupSignature: could not extract cert info, relaxed mode - accepting");
-        return {true, "OK"};
+        return {};
     }
 
     const std::string fileSubject  = WstrToUtf8(fileInfo.SubjectName);
@@ -366,8 +366,7 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
                   fileSubject, fileIssuer, fileSerial);
 
     // Determine the effective pin source
-    const bool hasReleaseSig = releaseSig.has_value();
-    const bool useFromConfig = hasReleaseSig ||
+    const bool useFromConfig = releaseSig.has_value() ||
                                strategy == SignatureVerificationStrategy::FromConfiguration;
 
     if (useFromConfig && releaseSig.has_value())
@@ -386,11 +385,11 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
             });
         }
 
-        bool pinMatch = PinMatches(pin.subjectName, fileSubject)
-                     && PinMatches(pin.issuerName,  fileIssuer)
-                     && PinMatches(pin.serialNumber, fileSerial)
-                     && PinMatches(pin.thumbprintSha1,   fileSha1)
-                     && PinMatches(pin.thumbprintSha256,  fileSha256);
+        const bool pinMatch = PinMatches(pin.subjectName,     fileSubject)
+                           && PinMatches(pin.issuerName,      fileIssuer)
+                           && PinMatches(pin.serialNumber,    fileSerial)
+                           && PinMatches(pin.thumbprintSha1,  fileSha1)
+                           && PinMatches(pin.thumbprintSha256, fileSha256);
 
         if (!pinMatch)
         {
@@ -403,11 +402,11 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
                           pin.serialNumber.value_or("<any>"),
                           pin.thumbprintSha1.value_or("<any>"),
                           pin.thumbprintSha256.value_or("<any>"));
-            return {false, "Publisher certificate does not match the configured pin"};
+            return std::unexpected("Publisher certificate does not match the configured pin");
         }
 
         spdlog::info("VerifySetupSignature: publisher pin matched (FromConfiguration)");
-        return {true, "OK"};
+        return {};
     }
 
     if (strategy == SignatureVerificationStrategy::FromUpdaterBinary && isUpdaterSigned)
@@ -424,18 +423,18 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifySetupSignature(
         {
             spdlog::error("VerifySetupSignature: publisher mismatch (FromUpdaterBinary): "
                           "updater='{}' setup='{}'", updaterSubject, fileSubject);
-            return {false, std::format(
+            return std::unexpected(std::format(
                 "Setup publisher ('{}') does not match updater publisher ('{}').",
-                fileSubject, updaterSubject)};
+                fileSubject, updaterSubject));
         }
 
         spdlog::info("VerifySetupSignature: publisher matched (FromUpdaterBinary, subjectName)");
-        return {true, "OK"};
+        return {};
     }
 
     // No pin configured and Relaxed policy - chain valid is sufficient
     spdlog::info("VerifySetupSignature: no publisher pin configured, accepting (chain valid)");
-    return {true, "OK"};
+    return {};
 }
 
 // ============================================================================
@@ -531,13 +530,13 @@ static bool ParseMinisignPublicKey(const char* pubKeyStr,
     return true;
 }
 
-std::tuple<bool, std::string> models::InstanceConfig::VerifyManifestSignature(
+std::expected<void, std::string> models::InstanceConfig::VerifyManifestSignature(
     const std::string& manifestBody,
     const std::string& minisigBody)
 {
     if (sodium_init() < 0)
     {
-        return {false, "Failed to initialize libsodium"};
+        return std::unexpected("Failed to initialize libsodium");
     }
 
     // Parse the .minisig sidecar
@@ -545,26 +544,27 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyManifestSignature(
     std::vector<unsigned char> sig;
     if (!ParseMinisigFile(minisigBody, keyId, sig))
     {
-        return {false, "Failed to parse manifest signature file (.minisig)"};
+        return std::unexpected("Failed to parse manifest signature file (.minisig)");
     }
 
     spdlog::debug("VerifyManifestSignature: key id from .minisig = {}", keyId);
 
     if (sig.size() != crypto_sign_BYTES)
     {
-        return {false, std::format("Invalid signature length: expected {}, got {}", crypto_sign_BYTES, sig.size())};
+        return std::unexpected(std::format("Invalid signature length: expected {}, got {}",
+                                           crypto_sign_BYTES, sig.size()));
     }
 
     // Decode the compiled-in public key
     std::vector<unsigned char> pubKey;
     if (!ParseMinisignPublicKey(NV_MANIFEST_PUBLIC_KEY, pubKey))
     {
-        return {false, "Failed to decode the compiled-in manifest public key (NV_MANIFEST_PUBLIC_KEY)"};
+        return std::unexpected("Failed to decode the compiled-in manifest public key (NV_MANIFEST_PUBLIC_KEY)");
     }
 
     if (pubKey.size() != crypto_sign_PUBLICKEYBYTES)
     {
-        return {false, "Invalid compiled-in public key length"};
+        return std::unexpected("Invalid compiled-in public key length");
     }
 
     // Verify signature over raw manifest bytes
@@ -578,11 +578,11 @@ std::tuple<bool, std::string> models::InstanceConfig::VerifyManifestSignature(
     if (result != 0)
     {
         spdlog::error("VerifyManifestSignature: Ed25519 signature verification FAILED");
-        return {false, "Manifest signature is invalid - the update manifest may have been tampered with"};
+        return std::unexpected("Manifest signature is invalid - the update manifest may have been tampered with");
     }
 
     spdlog::info("VerifyManifestSignature: manifest signature valid");
-    return {true, "OK"};
+    return {};
 }
 
 bool models::InstanceConfig::CheckAndUpdateManifestVersion(const uint64_t signedVersion) const

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -83,6 +83,26 @@ bool models::InstanceConfig::RunSelfUpdater() const
 
     const auto runDll = "rundll32.exe";
 
+    const auto& inst = remote.instance.value();
+    const std::string latestUrl = inst.latestUrl.value();
+
+    // Build optional integrity args to pass to the self-updater DLL.
+    // The self-updater verifies them before swapping the binary into place.
+    std::string checksumArgs;
+    if (inst.latestChecksum.has_value())
+    {
+        const auto& cs = inst.latestChecksum.value();
+        checksumArgs = std::format(" --checksum \"{}\" --checksum-alg \"{}\"",
+                                   cs.checksum,
+                                   magic_enum::enum_name(cs.checksumAlg));
+        spdlog::info("Passing checksum to self-updater: alg={} value={}",
+                     magic_enum::enum_name(cs.checksumAlg), cs.checksum);
+    }
+    else
+    {
+        spdlog::warn("No checksum available for self-updater binary; verification will be Authenticode-only");
+    }
+
     // if we can write to our directory, spawn under current user
     if (HasWritePermissions())
     {
@@ -95,10 +115,13 @@ bool models::InstanceConfig::RunSelfUpdater() const
         si.wShowWindow = SW_HIDE;
 
         std::stringstream argsStream;
-        // build CLI args
-        argsStream << "rundll32 \"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
-                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
-                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        argsStream << "rundll32 \"" << ads << "\",PerformUpdate"
+                   << " --silent"
+                   << " --log-level " << magic_enum::enum_name(spdlog::get_level())
+                   << " --pid " << GetCurrentProcessId()
+                   << " --path \"" << appPath.string() << "\""
+                   << " --url \"" << latestUrl << "\""
+                   << checksumArgs;
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 
@@ -130,10 +153,13 @@ bool models::InstanceConfig::RunSelfUpdater() const
         TryDisplayUACDialog();
 
         std::stringstream argsStream;
-        // build CLI args
-        argsStream << "\"" << ads << "\",PerformUpdate" << " --silent" << " --log-level "
-                   << magic_enum::enum_name(spdlog::get_level()) << " --pid " << GetCurrentProcessId() << " --path \""
-                   << appPath.string() << "\"" << " --url \"" << remote.instance.value().latestUrl.value() << "\"";
+        argsStream << "\"" << ads << "\",PerformUpdate"
+                   << " --silent"
+                   << " --log-level " << magic_enum::enum_name(spdlog::get_level())
+                   << " --pid " << GetCurrentProcessId()
+                   << " --path \"" << appPath.string() << "\""
+                   << " --url \"" << latestUrl << "\""
+                   << checksumArgs;
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -884,11 +884,11 @@ namespace
                             "Update blocked because NV_MANIFEST_PUBLIC_KEY is configured.");
                     }
 
-                    const auto [sigOk, sigReason] = VerifyManifestSignature(body, minisigBody);
-                    if (!sigOk)
+                    const auto sigResult = VerifyManifestSignature(body, minisigBody);
+                    if (!sigResult)
                     {
-                        spdlog::error("Manifest signature verification failed: {}", sigReason);
-                        return std::make_tuple(false, std::format("Manifest signature invalid: {}", sigReason));
+                        spdlog::error("Manifest signature verification failed: {}", sigResult.error());
+                        return std::make_tuple(false, std::format("Manifest signature invalid: {}", sigResult.error()));
                     }
 
                     spdlog::info("Manifest signature verified successfully");

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -786,7 +786,7 @@ namespace
 // RequestUpdateInfo
 // ============================================================================
 
-[[nodiscard]] std::tuple<bool, std::string> models::InstanceConfig::RequestUpdateInfo()
+[[nodiscard]] std::expected<void, std::string> models::InstanceConfig::RequestUpdateInfo()
 {
     auto conn = std::make_unique<RestClient::Connection>("");
 
@@ -863,7 +863,7 @@ namespace
                     break; // try next candidate URL
                 }
 
-                return std::make_tuple(false, std::format("HTTP error {}", errorMessage));
+                return std::unexpected(std::format("HTTP error {}", errorMessage));
             }
 
             try
@@ -888,7 +888,7 @@ namespace
                     if (sigCode != httplib::OK_200 || minisigBody.empty())
                     {
                         spdlog::error("Failed to fetch manifest signature from {} (code {})", minisigUrl, sigCode);
-                        return std::make_tuple(false,
+                        return std::unexpected(
                             "Manifest signature (.minisig) could not be fetched. "
                             "Update blocked because NV_MANIFEST_PUBLIC_KEY is configured.");
                     }
@@ -897,7 +897,7 @@ namespace
                     if (!sigResult)
                     {
                         spdlog::error("Manifest signature verification failed: {}", sigResult.error());
-                        return std::make_tuple(false, std::format("Manifest signature invalid: {}", sigResult.error()));
+                        return std::unexpected(std::format("Manifest signature invalid: {}", sigResult.error()));
                     }
 
                     spdlog::info("Manifest signature verified successfully");
@@ -926,7 +926,7 @@ namespace
                     if (!CheckAndUpdateManifestVersion(manifestVersion))
                     {
                         spdlog::error("Manifest version rollback detected (version {}), blocking update", manifestVersion);
-                        return std::make_tuple(false,
+                        return std::unexpected(
                             "The update manifest appears to be a downgrade attempt and has been rejected.");
                     }
                 }
@@ -941,7 +941,7 @@ namespace
                     {
                         spdlog::error("Release '{}' has a disallowed downloadUrl scheme: {}",
                                       release.name, release.downloadUrl);
-                        return std::make_tuple(false,
+                        return std::unexpected(
                             std::format("Release '{}' uses a non-HTTPS downloadUrl which is not allowed for security reasons.",
                                         release.name));
                     }
@@ -953,7 +953,7 @@ namespace
                     if (inst.latestUrl.has_value() && !IsAllowedDownloadUrl(inst.latestUrl.value()))
                     {
                         spdlog::error("instance.latestUrl has a disallowed scheme: {}", inst.latestUrl.value());
-                        return std::make_tuple(false,
+                        return std::unexpected(
                             "The self-updater URL (instance.latestUrl) uses a non-HTTPS scheme which is not allowed.");
                     }
                 }
@@ -963,7 +963,7 @@ namespace
                 {
                     spdlog::info("{} authority specified (or empty response), ignoring server parameters",
                                  magic_enum::enum_name(authority));
-                    return std::make_tuple(true, "OK");
+                    return {};
                 }
 
                 // merge values that can be supplied both locally and remotely
@@ -1005,7 +1005,7 @@ namespace
                         merged.signatureConfig = shared.signatureConfig.value();
                 }
 
-                return std::make_tuple(true, "OK");
+                return {};
             }
             catch (const json::exception& e)
             {
@@ -1019,7 +1019,7 @@ namespace
                     break; // try next candidate URL
                 }
 
-                return std::make_tuple(false, std::format("JSON parsing error: {}", e.what()));
+                return std::unexpected(std::format("JSON parsing error: {}", e.what()));
             }
             catch (const std::exception& e)
             {
@@ -1031,10 +1031,10 @@ namespace
                     break; // try next candidate URL
                 }
 
-                return std::make_tuple(false, std::format("Unknown error error: {}", e.what()));
+                return std::unexpected(std::format("Unknown error error: {}", e.what()));
             }
         }
     }
 
-    return std::make_tuple(false, "No update server URL could be reached");
+    return std::unexpected("No update server URL could be reached");
 }

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -811,6 +811,15 @@ namespace
     for (size_t i = 0; i < candidateUrls.size(); i++)
     {
         const auto& requestUrl = candidateUrls[ i ];
+
+        if (!IsAllowedDownloadUrl(requestUrl))
+        {
+            spdlog::error("Manifest URL {} uses a disallowed scheme and will not be fetched", requestUrl);
+            // Treat as unavailable and try next candidate; if none remain, the
+            // outer loop exits and the caller receives the "no server reachable" error.
+            continue;
+        }
+
         spdlog::info("Requesting update info from {} ({}/{})", requestUrl, i + 1, candidateUrls.size());
 
         // ReSharper disable once CppTooWideScopeInitStatement

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -751,6 +751,41 @@ int models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, c
     }
 }
 
+// ============================================================================
+// Helpers
+// ============================================================================
+
+namespace
+{
+    /**
+     * \brief Returns true if the URL uses HTTPS (or, in debug builds, HTTP localhost).
+     * Rejects http://, file://, and any other non-HTTPS scheme.
+     */
+    bool IsAllowedDownloadUrl(const std::string& url)
+    {
+        if (url.empty()) return false;
+
+        // HTTPS is always allowed
+        if (url.rfind("https://", 0) == 0) return true;
+
+#if !defined(NDEBUG) || defined(NV_FLAGS_ALLOW_HTTP_DOWNLOAD)
+        // In debug builds, allow plain HTTP for local test servers
+        if (url.rfind("http://localhost", 0) == 0 ||
+            url.rfind("http://127.0.0.1", 0) == 0 ||
+            url.rfind("http://[::1]", 0) == 0)
+        {
+            return true;
+        }
+#endif
+
+        return false;
+    }
+}
+
+// ============================================================================
+// RequestUpdateInfo
+// ============================================================================
+
 [[nodiscard]] std::tuple<bool, std::string> models::InstanceConfig::RequestUpdateInfo()
 {
     auto conn = std::make_unique<RestClient::Connection>("");
@@ -824,6 +859,42 @@ int models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, c
 
             try
             {
+                //
+                // Layer 3: Manifest signature verification (Ed25519 / minisign)
+                // Must happen BEFORE json::parse so a tampered body is never trusted.
+                //
+#if defined(NV_MANIFEST_PUBLIC_KEY)
+                {
+                    // Derive the .minisig sidecar URL by appending ".minisig" to the manifest URL
+                    const std::string minisigUrl = requestUrl + ".minisig";
+                    spdlog::debug("Fetching manifest signature from {}", minisigUrl);
+
+                    auto sigConn = std::make_unique<RestClient::Connection>("");
+                    sigConn->SetUserAgent(ua);
+                    sigConn->SetTimeout(MAX_TIMEOUT_SECS);
+                    SetCommonHeaders(sigConn);
+
+                    auto [ sigCode, minisigBody, _2 ] = sigConn->get(minisigUrl);
+
+                    if (sigCode != httplib::OK_200 || minisigBody.empty())
+                    {
+                        spdlog::error("Failed to fetch manifest signature from {} (code {})", minisigUrl, sigCode);
+                        return std::make_tuple(false,
+                            "Manifest signature (.minisig) could not be fetched. "
+                            "Update blocked because NV_MANIFEST_PUBLIC_KEY is configured.");
+                    }
+
+                    const auto [sigOk, sigReason] = VerifyManifestSignature(body, minisigBody);
+                    if (!sigOk)
+                    {
+                        spdlog::error("Manifest signature verification failed: {}", sigReason);
+                        return std::make_tuple(false, std::format("Manifest signature invalid: {}", sigReason));
+                    }
+
+                    spdlog::info("Manifest signature verified successfully");
+                }
+#endif
+
                 const json reply = json::parse(body);
                 remote = reply.get<UpdateResponse>();
 
@@ -836,6 +907,48 @@ int models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, c
                     return lhs.GetSemVersion() > rhs.GetSemVersion();
                 });
 
+                //
+                // Layer 3: Rollback / downgrade protection
+                //
+#if defined(NV_MANIFEST_PUBLIC_KEY)
+                if (reply.contains("manifestVersion") && reply["manifestVersion"].is_number_unsigned())
+                {
+                    const uint64_t manifestVersion = reply["manifestVersion"].get<uint64_t>();
+                    if (!CheckAndUpdateManifestVersion(manifestVersion))
+                    {
+                        spdlog::error("Manifest version rollback detected (version {}), blocking update", manifestVersion);
+                        return std::make_tuple(false,
+                            "The update manifest appears to be a downgrade attempt and has been rejected.");
+                    }
+                }
+#endif
+
+                //
+                // Layer 5: Enforce HTTPS on all download URLs from the manifest
+                //
+                for (const auto& release : remote.releases)
+                {
+                    if (!IsAllowedDownloadUrl(release.downloadUrl))
+                    {
+                        spdlog::error("Release '{}' has a disallowed downloadUrl scheme: {}",
+                                      release.name, release.downloadUrl);
+                        return std::make_tuple(false,
+                            std::format("Release '{}' uses a non-HTTPS downloadUrl which is not allowed for security reasons.",
+                                        release.name));
+                    }
+                }
+
+                if (remote.instance.has_value())
+                {
+                    const auto& inst = remote.instance.value();
+                    if (inst.latestUrl.has_value() && !IsAllowedDownloadUrl(inst.latestUrl.value()))
+                    {
+                        spdlog::error("instance.latestUrl has a disallowed scheme: {}", inst.latestUrl.value());
+                        return std::make_tuple(false,
+                            "The self-updater URL (instance.latestUrl) uses a non-HTTPS scheme which is not allowed.");
+                    }
+                }
+
                 // bail out now if we are not supposed to obey the server settings
                 if (authority == Authority::Local || !reply.contains("shared"))
                 {
@@ -844,7 +957,7 @@ int models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, c
                     return std::make_tuple(true, "OK");
                 }
 
-                // merge values that can be supplied both locally end remotely
+                // merge values that can be supplied both locally and remotely
                 if (remote.shared.has_value())
                 {
                     const auto& shared = remote.shared.value();
@@ -868,6 +981,19 @@ int models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, c
                     if (shared.downloadLocation.has_value()) merged.downloadLocation = shared.downloadLocation.value();
 
                     if (shared.runAsTemporaryCopy.has_value()) merged.runAsTemporaryCopy = shared.runAsTemporaryCopy.value();
+
+                    // Signature verification settings from server (do not override strict mode set by CLI)
+                    if (shared.signatureVerificationMode.has_value() && !strictVerification)
+                        merged.signatureVerificationMode = shared.signatureVerificationMode.value();
+
+                    if (shared.signaturePolicy.has_value() && !strictVerification)
+                        merged.signaturePolicy = shared.signaturePolicy.value();
+
+                    if (shared.signatureStrategy.has_value())
+                        merged.signatureStrategy = shared.signatureStrategy.value();
+
+                    if (shared.signatureConfig.has_value())
+                        merged.signatureConfig = shared.signatureConfig.value();
                 }
 
                 return std::make_tuple(true, "OK");

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -998,10 +998,10 @@ namespace
                     if (shared.signaturePolicy.has_value() && !strictVerification)
                         merged.signaturePolicy = shared.signaturePolicy.value();
 
-                    if (shared.signatureStrategy.has_value())
+                    if (shared.signatureStrategy.has_value() && !strictVerification)
                         merged.signatureStrategy = shared.signatureStrategy.value();
 
-                    if (shared.signatureConfig.has_value())
+                    if (shared.signatureConfig.has_value() && !strictVerification)
                         merged.signatureConfig = shared.signatureConfig.value();
                 }
 

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -320,7 +320,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
     else
     {
         // Extract extended cert info for subjectName comparison
-        if (crypto::ExtractSignatureInformation(ConvertAnsiToWide(appPath.string()).c_str(), &appCertInfo))
+        if (crypto::ExtractSignatureInformation(appPath.wstring().c_str(), &appCertInfo))
         {
             isUpdaterSigned = true;
             spdlog::info("Updater executable is signed; subject='{}'",

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -2,6 +2,7 @@
 #include "Common.h"
 #include "Util.h"
 #include "InstanceConfig.hpp"
+#include "NAuthenticode.h"
 
 
 models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, PDWORD abortError)
@@ -297,25 +298,42 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
         additionalHeaders.insert(std::make_pair(name, value));
     }
 
-    /*
-    if (!NVerifyFileSignature(ConvertAnsiToWide(appPath.string()).c_str(), &appSigInfo))
+    //
+    // Capture the updater's own Authenticode signature (used for FromUpdaterBinary publisher pinning).
+    // We do NOT pass WTD_LIFETIME_SIGNING_FLAG so that time-stamped certs remain valid after expiry.
+    //
+    if (!NVerifyFileSignature(appPath.wstring().c_str(), &appSigInfo))
     {
         switch (appSigInfo.lValidationResult)
         {
-        case TRUST_E_NOSIGNATURE:
-            spdlog::warn("Executable {} has no signature", appPath.string());
-            break;
-        default:
-            spdlog::warn("Grabbing signature information for {} failed unexpectedly", appPath.string());
-            break;
+            case TRUST_E_NOSIGNATURE:
+                spdlog::info("Updater executable {} is not signed (FromUpdaterBinary pinning unavailable)",
+                             appPath.string());
+                break;
+            default:
+                spdlog::warn("Updater executable {} signature validation returned {:#x}",
+                             appPath.string(), static_cast<unsigned long>(appSigInfo.lValidationResult));
+                break;
+        }
+        isUpdaterSigned = false;
+    }
+    else
+    {
+        // Extract extended cert info for subjectName comparison
+        if (crypto::ExtractSignatureInformation(ConvertAnsiToWide(appPath.string()).c_str(), &appCertInfo))
+        {
+            isUpdaterSigned = true;
+            spdlog::info("Updater executable is signed; subject='{}'",
+                         appCertInfo.SubjectName
+                             ? ConvertWideToANSI(std::wstring(appCertInfo.SubjectName))
+                             : "(unknown)");
+        }
+        else
+        {
+            spdlog::warn("Updater is signed but cert info could not be extracted");
+            isUpdaterSigned = false;
         }
     }
-
-    // TODO: implement me!
-
-    crypto::SIGNATURE_INFORMATION sigInf = {};
-    crypto::ExtractSignatureInformation(ConvertAnsiToWide(appPath.string()).c_str(), &sigInf);
-    */
 
     //
     // Merge from config file, if available
@@ -375,6 +393,23 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
 #endif
 
     this->forceLocalVersion = static_cast<bool>(cmdl({NV_CLI_PARAM_FORCE_LOCAL_VERSION}));
+
+    // Strict verification: checksum required, Authenticode required, publisher pin must match
+    this->strictVerification = static_cast<bool>(cmdl[{NV_CLI_STRICT_VERIFICATION}]);
+    if (this->strictVerification)
+    {
+        spdlog::info("Strict verification mode is ACTIVE");
+        // Strict mode implies Required signature verification mode if not already set higher
+        if (merged.signatureVerificationMode == SignatureVerificationMode::WhenPresent ||
+            merged.signatureVerificationMode == SignatureVerificationMode::Disabled)
+        {
+            merged.signatureVerificationMode = SignatureVerificationMode::Required;
+        }
+        if (merged.signaturePolicy == SignatureComparisonPolicy::Relaxed)
+        {
+            merged.signaturePolicy = SignatureComparisonPolicy::Strict;
+        }
+    }
 
     if (this->forceLocalVersion)
     {
@@ -457,6 +492,11 @@ models::InstanceConfig::~InstanceConfig()
     if (appSigInfo.lValidationResult == ERROR_SUCCESS)
     {
         NCertFreeSigInfo(&appSigInfo);
+    }
+
+    if (isUpdaterSigned)
+    {
+        crypto::FreeSignatureInformation(&appCertInfo);
     }
 
     // Ensure no in-flight download uses libcurl while we tear down global state.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -689,18 +689,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                         ImGui::Text(ICON_FK_SHIELD " Verifying download integrity...");
 
                         // Run synchronously (fast: checksum + WinVerifyTrust; no UI blocking concern)
-                        const auto [verOk, verReason] = cfg.VerifyReleaseIntegrity();
+                        const auto verResult = cfg.VerifyReleaseIntegrity();
 
-                        if (verOk)
+                        if (verResult)
                         {
                             spdlog::info("Verification passed, advancing to install");
                             instStep = DownloadAndInstallStep::PrepareInstall;
                         }
                         else
                         {
-                            spdlog::error("Verification failed: {}", verReason);
-                            // Store reason so VerificationFailed can display it
-                            cfg.SetLastDownloadError(verReason);
+                            spdlog::error("Verification failed: {}", verResult.error());
+                            cfg.SetLastDownloadError(verResult.error());
                             instStep = DownloadAndInstallStep::VerificationFailed;
                         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -679,9 +679,63 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                         break;
                     case DownloadAndInstallStep::DownloadSucceeded:
 
-                        instStep = DownloadAndInstallStep::PrepareInstall;
+                        spdlog::info("Download finished successfully, advancing to verification step");
+                        instStep = DownloadAndInstallStep::Verifying;
 
-                        spdlog::info("Download finished successfully");
+                        break;
+
+                    case DownloadAndInstallStep::Verifying:
+                    {
+                        ImGui::Text(ICON_FK_SHIELD " Verifying download integrity...");
+
+                        // Run synchronously (fast: checksum + WinVerifyTrust; no UI blocking concern)
+                        const auto [verOk, verReason] = cfg.VerifyReleaseIntegrity();
+
+                        if (verOk)
+                        {
+                            spdlog::info("Verification passed, advancing to install");
+                            instStep = DownloadAndInstallStep::PrepareInstall;
+                        }
+                        else
+                        {
+                            spdlog::error("Verification failed: {}", verReason);
+                            // Store reason so VerificationFailed can display it
+                            cfg.SetLastDownloadError(verReason);
+                            instStep = DownloadAndInstallStep::VerificationFailed;
+                        }
+
+                        break;
+                    }
+
+                    case DownloadAndInstallStep::VerificationFailed:
+
+                        isCancelDisabled = false;
+                        isBackDisabled = false;
+                        status = NV_E_SIGNATURE_INVALID;
+
+                        ImGui::Text(ICON_FK_EXCLAMATION_TRIANGLE " Verification failed");
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(10));
+
+                        if (const auto details = cfg.GetLastDownloadError(); !details.empty())
+                        {
+                            ImGui::TextWrapped("%s", details.c_str());
+                        }
+                        else
+                        {
+                            ImGui::TextWrapped("The downloaded file could not be verified. "
+                                               "It may have been tampered with or corrupted.");
+                        }
+
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(35));
+                        if (ImGui::Button("Retry download"))
+                        {
+                            cfg.SetLastDownloadError({});
+                            instStep = DownloadAndInstallStep::Begin;
+                            currentPage = WizardPage::DownloadAndInstall;
+                        }
+
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
+                        ImGui::Text("Press 'Cancel' to abort and close.");
 
                         break;
                     case DownloadAndInstallStep::DownloadFailed:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -207,12 +207,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     }
 
     // contact update server and get latest state and config
-    if (const auto ret = cfg.RequestUpdateInfo(); !std::get<0>(ret))
+    if (const auto ret = cfg.RequestUpdateInfo(); !ret)
     {
         // TODO: add fallback actions
 
         spdlog::critical("Failed to get server response");
-        cfg.TryDisplayErrorDialog("Failed to get server response", std::get<1>(ret));
+        cfg.TryDisplayErrorDialog("Failed to get server response", ret.error());
         return NV_E_SERVER_RESPONSE;
     }
 

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -171,7 +171,7 @@ namespace models
          * \brief Requests the update configuration from the remote server.
          * \return True on success, false otherwise.
          */
-        [[nodiscard]] std::tuple<bool, std::string> RequestUpdateInfo();
+        [[nodiscard]] std::expected<void, std::string> RequestUpdateInfo();
 
         /**
          * \brief Checks if a newer release than the local version is available.

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -420,12 +420,12 @@ namespace models
 
         /**
          * \brief Verifies the downloaded setup file integrity (checksum + Authenticode publisher pin).
-         * \return Tuple of (success, human-readable reason on failure).
+         * \return Empty on success; unexpected error string on failure.
          * \remarks Called between DownloadSucceeded and PrepareInstall in the UI state machine.
          *          Checksum: if present in the release it MUST match; absent = allowed in Relaxed, rejected in strict mode.
          *          Signature: governed by merged.signatureVerificationMode (WhenPresent / Required).
          */
-        [[nodiscard]] std::tuple<bool, std::string> VerifyReleaseIntegrity();
+        [[nodiscard]] std::expected<void, std::string> VerifyReleaseIntegrity();
 
         /**
          * \brief Validates the Authenticode signature of a file and optionally pins the publisher.
@@ -433,9 +433,9 @@ namespace models
          * \param releaseSig Optional per-release certificate pin (overrides global strategy).
          * \param policy The comparison policy to apply.
          * \param strategy The pin strategy to use.
-         * \return Tuple of (success, human-readable reason on failure).
+         * \return Empty on success; unexpected error string on failure.
          */
-        [[nodiscard]] std::tuple<bool, std::string> VerifySetupSignature(
+        [[nodiscard]] std::expected<void, std::string> VerifySetupSignature(
             const std::filesystem::path& filePath,
             const std::optional<models::SignatureConfig>& releaseSig,
             models::SignatureComparisonPolicy policy,
@@ -446,9 +446,9 @@ namespace models
          * \brief Verifies a detached minisign Ed25519 signature over the raw manifest body.
          * \param manifestBody The raw bytes of the fetched JSON.
          * \param minisigBody The raw contents of the .minisig sidecar file.
-         * \return Tuple of (success, human-readable reason on failure).
+         * \return Empty on success; unexpected error string on failure.
          */
-        [[nodiscard]] static std::tuple<bool, std::string> VerifyManifestSignature(
+        [[nodiscard]] static std::expected<void, std::string> VerifyManifestSignature(
             const std::string& manifestBody,
             const std::string& minisigBody);
 

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -90,9 +90,15 @@ namespace models
         bool overrideSuccessCode{false};
         /** The value supplied by NV_CLI_PARAM_OVERRIDE_OK */
         int overriddenSuccessCode{ERROR_SUCCESS};
+        /** True if --strict-verification was passed or enabled via config */
+        bool strictVerification{false};
 
-        // TODO: implement me!
+        /** WinTrust result for the updater exe itself (populated at startup) */
         NSIGINFO appSigInfo{};
+        /** Extended cert info for the updater exe (populated at startup when signed) */
+        crypto::SIGNATURE_INFORMATION appCertInfo{};
+        /** True if the updater exe itself carries a valid Authenticode signature */
+        bool isUpdaterSigned{false};
 
         int DownloadRelease(curl_progress_callback progressFn, int releaseIndex);
 
@@ -158,6 +164,8 @@ namespace models
          * \brief Returns the most recent download failure reason, if any.
          */
         [[nodiscard]] std::string GetLastDownloadError() const { return lastDownloadError; }
+
+        void SetLastDownloadError(const std::string& error) { lastDownloadError = error; }
 
         /**
          * \brief Requests the update configuration from the remote server.
@@ -409,6 +417,48 @@ namespace models
         {
             return this->overrideSuccessCode ? this->overriddenSuccessCode : exitCode;
         }
+
+        /**
+         * \brief Verifies the downloaded setup file integrity (checksum + Authenticode publisher pin).
+         * \return Tuple of (success, human-readable reason on failure).
+         * \remarks Called between DownloadSucceeded and PrepareInstall in the UI state machine.
+         *          Checksum: if present in the release it MUST match; absent = allowed in Relaxed, rejected in strict mode.
+         *          Signature: governed by merged.signatureVerificationMode (WhenPresent / Required).
+         */
+        [[nodiscard]] std::tuple<bool, std::string> VerifyReleaseIntegrity();
+
+        /**
+         * \brief Validates the Authenticode signature of a file and optionally pins the publisher.
+         * \param filePath The file to verify.
+         * \param releaseSig Optional per-release certificate pin (overrides global strategy).
+         * \param policy The comparison policy to apply.
+         * \param strategy The pin strategy to use.
+         * \return Tuple of (success, human-readable reason on failure).
+         */
+        [[nodiscard]] std::tuple<bool, std::string> VerifySetupSignature(
+            const std::filesystem::path& filePath,
+            const std::optional<models::SignatureConfig>& releaseSig,
+            models::SignatureComparisonPolicy policy,
+            models::SignatureVerificationStrategy strategy) const;
+
+#if defined(NV_MANIFEST_PUBLIC_KEY)
+        /**
+         * \brief Verifies a detached minisign Ed25519 signature over the raw manifest body.
+         * \param manifestBody The raw bytes of the fetched JSON.
+         * \param minisigBody The raw contents of the .minisig sidecar file.
+         * \return Tuple of (success, human-readable reason on failure).
+         */
+        [[nodiscard]] static std::tuple<bool, std::string> VerifyManifestSignature(
+            const std::string& manifestBody,
+            const std::string& minisigBody);
+
+        /**
+         * \brief Reads and enforces the manifest version anti-rollback counter from the registry.
+         * \param signedVersion The monotonic version from the verified manifest.
+         * \return True if the version is acceptable (>= stored), false if it is a rollback attempt.
+         */
+        [[nodiscard]] bool CheckAndUpdateManifestVersion(uint64_t signedVersion) const;
+#endif
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(InstanceConfig, serverUrlTemplate, fallbackServerUrlTemplates, filenameRegex,

--- a/src/models/MergedConfig.hpp
+++ b/src/models/MergedConfig.hpp
@@ -2,6 +2,7 @@
 
 #include "ProductDetection.hpp"
 #include "DownloadLocationConfig.h"
+#include "SignatureValidation.hpp"
 
 using json = nlohmann::json;
 
@@ -28,6 +29,14 @@ namespace models
         DownloadLocationConfig downloadLocation;
         /** True to run as temporary copy */
         bool runAsTemporaryCopy{false};
+        /** Authenticode verification mode for downloaded setups */
+        SignatureVerificationMode signatureVerificationMode{SignatureVerificationMode::WhenPresent};
+        /** Authenticode comparison policy (Relaxed = chain only, Strict = must match pin) */
+        SignatureComparisonPolicy signaturePolicy{SignatureComparisonPolicy::Relaxed};
+        /** Authenticode pin strategy (FromUpdaterBinary pins subjectName; FromConfiguration uses explicit config) */
+        SignatureVerificationStrategy signatureStrategy{SignatureVerificationStrategy::FromUpdaterBinary};
+        /** Explicit certificate pin (used with FromConfiguration strategy) */
+        std::optional<SignatureConfig> signatureConfig;
 
         MergedConfig() : windowTitle(NV_WINDOW_TITLE), productName(NV_PRODUCT_NAME) { }
 
@@ -51,5 +60,9 @@ namespace models
                                                     detection,
                                                     installationErrorUrl,
                                                     downloadLocation,
-                                                    runAsTemporaryCopy)
+                                                    runAsTemporaryCopy,
+                                                    signatureVerificationMode,
+                                                    signaturePolicy,
+                                                    signatureStrategy,
+                                                    signatureConfig)
 }

--- a/src/models/SharedConfig.hpp
+++ b/src/models/SharedConfig.hpp
@@ -2,6 +2,7 @@
 
 #include "ProductDetection.hpp"
 #include "DownloadLocationConfig.h"
+#include "SignatureValidation.hpp"
 
 using json = nlohmann::json;
 
@@ -28,6 +29,14 @@ namespace models
         std::optional<DownloadLocationConfig> downloadLocation;
         /** True to run as temporary copy */
         std::optional<bool> runAsTemporaryCopy;
+        /** Global Authenticode verification mode (default: WhenPresent) */
+        std::optional<SignatureVerificationMode> signatureVerificationMode;
+        /** Global Authenticode comparison policy (default: Relaxed) */
+        std::optional<SignatureComparisonPolicy> signaturePolicy;
+        /** Global Authenticode pin strategy (default: FromUpdaterBinary) */
+        std::optional<SignatureVerificationStrategy> signatureStrategy;
+        /** Global Authenticode certificate pin (used with FromConfiguration strategy) */
+        std::optional<SignatureConfig> signatureConfig;
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SharedConfig,
@@ -37,5 +46,9 @@ namespace models
                                                     detection,
                                                     installationErrorUrl,
                                                     downloadLocation,
-                                                    runAsTemporaryCopy)
+                                                    runAsTemporaryCopy,
+                                                    signatureVerificationMode,
+                                                    signaturePolicy,
+                                                    signatureStrategy,
+                                                    signatureConfig)
 }

--- a/src/models/SignatureValidation.hpp
+++ b/src/models/SignatureValidation.hpp
@@ -6,6 +6,9 @@ namespace models
 {
     /**
      * \brief The policy to abide by when comparing signatures.
+     *
+     * Relaxed: a valid, trusted Authenticode chain is sufficient.
+     * Strict:  the chain must be valid AND the cert identity must match the configured pin.
      */
     enum class SignatureComparisonPolicy
     {
@@ -24,6 +27,9 @@ namespace models
 
     /**
      * \brief The strategy on how to verify if the setup signature is trusted.
+     *
+     * FromUpdaterBinary: pin on the updater exe's own signing cert (subjectName only - renewal-safe).
+     * FromConfiguration: pin on explicit values from the signed manifest / local config.
      */
     enum class SignatureVerificationStrategy
     {
@@ -41,15 +47,59 @@ namespace models
                                  })
 
     /**
-     * \brief Authenticode signature details.
+     * \brief Controls whether signature verification of the setup binary is enforced.
+     *
+     * Disabled:    no Authenticode check is performed.
+     * WhenPresent: check only if the setup is signed; unsigned setups are allowed (default).
+     * Required:    a valid Authenticode chain is mandatory; unsigned setups are rejected.
+     */
+    enum class SignatureVerificationMode
+    {
+        Disabled,
+        WhenPresent,
+        Required,
+        Invalid = -1
+    };
+
+    using svm = SignatureVerificationMode;
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(SignatureVerificationMode, {
+                                 {svm::Invalid, nullptr},
+                                 {svm::Disabled, magic_enum::enum_name(svm::Disabled)},
+                                 {svm::WhenPresent, magic_enum::enum_name(svm::WhenPresent)},
+                                 {svm::Required, magic_enum::enum_name(svm::Required)},
+                                 })
+
+    /**
+     * \brief Authenticode certificate pin details.
+     *
+     * Cert fields by renewal stability:
+     *   Stable  : subjectName  (tied to the legal entity - default pin for FromUpdaterBinary)
+     *   Volatile: serialNumber, thumbprintSha1, thumbprintSha256 (change on every renewal)
+     *   Semi-stable: issuerName (changes when CA rotates intermediates or you switch CA)
+     *
+     * Serial / thumbprint pinning is ONLY sound when these values travel inside the signed manifest
+     * (FromConfiguration) so they can be rotated on cert renewal without redeploying the updater.
      */
     class SignatureConfig
     {
     public:
+        /** CA / issuer display name (semi-stable - use with caution across renewals) */
         std::optional<std::string> issuerName;
+        /** Subject / organization name - stable across renewals; default FromUpdaterBinary pin field */
         std::optional<std::string> subjectName;
+        /** Certificate serial number - volatile; only safe via signed manifest (FromConfiguration) */
         std::optional<std::string> serialNumber;
+        /** SHA-1 thumbprint (hex) - volatile; only safe via signed manifest (FromConfiguration) */
+        std::optional<std::string> thumbprintSha1;
+        /** SHA-256 thumbprint (hex) - volatile; only safe via signed manifest (FromConfiguration) */
+        std::optional<std::string> thumbprintSha256;
     };
 
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SignatureConfig, issuerName, subjectName, serialNumber)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SignatureConfig,
+                                                    issuerName,
+                                                    subjectName,
+                                                    serialNumber,
+                                                    thumbprintSha1,
+                                                    thumbprintSha256)
 }

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -55,5 +55,5 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl)
+      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl, errorFallbackUrl)
 }

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "UpdateRelease.hpp"
+
 namespace models
 {
     class ExitCodeCheck;
@@ -16,6 +18,11 @@ namespace models
         std::optional<std::string> latestVersion;
         /** URL of the latest updater binary */
         std::optional<std::string> latestUrl;
+        /**
+         * \brief Optional checksum of the self-updater binary at latestUrl.
+         * Passed to the self-updater DLL so it can verify the download before swapping.
+         */
+        std::optional<ChecksumParameters> latestChecksum;
         /** Optional URL pointing to an emergency announcement web page */
         std::optional<std::string> emergencyUrl;
         /** The exit code parameters */
@@ -48,5 +55,5 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-      UpdateConfig, updatesDisabled, latestVersion, latestUrl, emergencyUrl, exitCode, helpUrl)
+      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl)
 }

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CommonTypes.hpp"
+#include "SignatureValidation.hpp"
 #include "../ADL.hpp"
 
 namespace models
@@ -77,6 +78,17 @@ namespace models
         std::optional<ChecksumParameters> checksum;
         /** If set, this release is ignored and not presented to the user */
         std::optional<bool> disabled;
+        /**
+         * \brief Optional Authenticode certificate pin for this release.
+         * When present, the downloaded setup's signing cert is compared against these values.
+         * Implies signatureStrategy = FromConfiguration.
+         * Serial/thumbprint fields here are safe because they travel inside the signed manifest.
+         */
+        std::optional<SignatureConfig> signature;
+        /** Override the global Authenticode verification policy for this specific release */
+        std::optional<SignatureComparisonPolicy> signaturePolicy;
+        /** Override the global Authenticode pin strategy for this specific release */
+        std::optional<SignatureVerificationStrategy> signatureStrategy;
         /** The file hash to use in product detection */
         std::optional<ChecksumParameters> detectionChecksum;
         /** Size of the remote file in bytes */
@@ -116,6 +128,9 @@ namespace models
                                                     exitCode,
                                                     checksum,
                                                     disabled,
+                                                    signature,
+                                                    signaturePolicy,
+                                                    signatureStrategy,
                                                     detectionChecksum,
                                                     detectionSize,
                                                     detectionVersion,

--- a/src/pch.h
+++ b/src/pch.h
@@ -84,3 +84,10 @@
 #include "Crypto.h"
 #include "UI.h"
 #include "Formatters.h"
+
+//
+// Manifest signing (libsodium, only when a public key is compiled in)
+//
+#if defined(NV_MANIFEST_PUBLIC_KEY)
+#include <sodium.h>
+#endif

--- a/src/vīcĭus.vcxproj
+++ b/src/vīcĭus.vcxproj
@@ -318,6 +318,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Crypto.cpp" />
+    <ClCompile Include="InstanceConfig.Security.cpp" />
     <ClCompile Include="imgui_md.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,6 +29,7 @@
     "cpp-httplib",
     "libzip",
     "neflib",
-    "directxtk"
+    "directxtk",
+    "libsodium"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added layered secure update verification: optional checksum validation, Authenticode signature with publisher pin checks, HTTPS-only enforcement, and manifest anti-rollback via version tracking.
  * Added `--strict-verification` plus self-update checksum options (`--checksum`, `--checksum-alg`).
  * Added Ed25519/minisign manifest signature verification (when enabled) and included a secure updates example configuration.
* **Bug Fixes**
  * Strengthened verification failure recovery: download/install now verifies integrity before proceeding, with clear failure, retry, and safe rollback behavior.
* **Documentation/Build**
  * Documented the secure update pipeline; enabled manifest signature verification in builds when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->