### PR TITLE
Added option to hide reminder button

### DIFF
--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -1005,6 +1005,8 @@ namespace
 
                     if (shared.signatureConfig.has_value() && !strictVerification)
                         merged.signatureConfig = shared.signatureConfig.value();
+
+                    if (shared.hideRemindButton.has_value()) merged.hideRemindButton = shared.hideRemindButton.value();
                 }
 
                 return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -624,12 +624,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                 }
                 ImGui::PopStyleColor(3);
 
-                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(20));
-                if (ImGui::Button(ICON_FK_CLOCK_O " Remind me tomorrow"))
+                if (!cfg.IsRemindButtonHidden())
                 {
-                    cfg.SetPostponeData();
-                    status = cfg.GetSuccessExitCode(NV_S_USER_POSTPONED);
-                    PostQuitMessage((int)status);
+                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(20));
+                    if (ImGui::Button(ICON_FK_CLOCK_O " Remind me tomorrow"))
+                    {
+                        cfg.SetPostponeData();
+                        status = cfg.GetSuccessExitCode(NV_S_USER_POSTPONED);
+                        PostQuitMessage((int)status);
+                    }
                 }
 
                 if (cfg.GetHelpUrl().has_value())

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -145,6 +145,7 @@ namespace models
 
         std::string GetWindowTitle() const { return merged.windowTitle; }
         std::string GetProductName() const { return merged.productName; }
+        bool IsRemindButtonHidden() const { return merged.hideRemindButton; }
 
         bool SetSelectedRelease(const int releaseIndex = 0)
         {

--- a/src/models/MergedConfig.hpp
+++ b/src/models/MergedConfig.hpp
@@ -37,6 +37,8 @@ namespace models
         SignatureVerificationStrategy signatureStrategy{SignatureVerificationStrategy::FromUpdaterBinary};
         /** Explicit certificate pin (used with FromConfiguration strategy) */
         std::optional<SignatureConfig> signatureConfig;
+        /** True to hide the "Remind me tomorrow" button in the UI */
+        bool hideRemindButton{false};
 
         MergedConfig() : windowTitle(NV_WINDOW_TITLE), productName(NV_PRODUCT_NAME) { }
 
@@ -64,5 +66,6 @@ namespace models
                                                     signatureVerificationMode,
                                                     signaturePolicy,
                                                     signatureStrategy,
-                                                    signatureConfig)
+                                                    signatureConfig,
+                                                    hideRemindButton)
 }

--- a/src/models/SharedConfig.hpp
+++ b/src/models/SharedConfig.hpp
@@ -37,6 +37,8 @@ namespace models
         std::optional<SignatureVerificationStrategy> signatureStrategy;
         /** Global Authenticode certificate pin (used with FromConfiguration strategy) */
         std::optional<SignatureConfig> signatureConfig;
+        /** True to hide the "Remind me tomorrow" button in the UI */
+        std::optional<bool> hideRemindButton;
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SharedConfig,
@@ -50,5 +52,6 @@ namespace models
                                                     signatureVerificationMode,
                                                     signaturePolicy,
                                                     signatureStrategy,
-                                                    signatureConfig)
+                                                    signatureConfig,
+                                                    hideRemindButton)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hiding the “Remind me tomorrow” button based on configuration.
  * The start page now respects this setting and only shows the button when enabled.

* **Bug Fixes**
  * Kept the existing postpone flow intact when the reminder button is shown and used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->