### PR TITLE
Added `runAsAdmin` support

### DIFF
--- a/examples/configs/example_secure_updates.json
+++ b/examples/configs/example_secure_updates.json
@@ -67,7 +67,10 @@
 
       "exitCode": {
         "successCodes": [0, 3010]
-      }
+      },
+
+      "$comment_runAsAdmin": "Optional. Set to true to launch the setup elevated (As Administrator) via the 'runas' verb. Useful when the installer has no elevation manifest of its own.",
+      "runAsAdmin": true
     }
   ]
 }

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -227,6 +227,7 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
     const auto& release = this->GetSelectedRelease();
     const auto& tempFile = this->GetLocalReleaseTempFilePath();
     std::string openFile = tempFile.string();
+    const bool runAsAdmin = this->RunAsAdmin();
 
     DWORD win32Error = ERROR_SUCCESS;
     DWORD exitCode = 0;
@@ -356,7 +357,7 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
             execInfo.cbSize = sizeof(SHELLEXECUTEINFO);
             execInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
             execInfo.hwnd = this->windowHandle;
-            execInfo.lpVerb = NULL;
+            execInfo.lpVerb = runAsAdmin ? "runas" : NULL;
             execInfo.lpFile = openFile.c_str();
             execInfo.lpParameters = args.c_str();
             execInfo.lpDirectory = NULL;
@@ -383,8 +384,46 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
         }
     }
     //
-    // Executables can directly be spawned via CreateProcess
+    // Executables: if elevation is requested use ShellExecuteEx ("runas"),
+    // otherwise spawn directly via CreateProcess.
     //
+    else if (runAsAdmin)
+    {
+        const std::string args = release.launchArguments.value_or(std::string{});
+
+        SHELLEXECUTEINFOA execInfo = {};
+        execInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+        execInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+        execInfo.hwnd = this->windowHandle;
+        execInfo.lpVerb = "runas";
+        execInfo.lpFile = openFile.c_str();
+        execInfo.lpParameters = args.c_str();
+        execInfo.lpDirectory = NULL;
+        execInfo.nShow = SW_SHOW;
+        execInfo.hInstApp = NULL;
+
+        if (!ShellExecuteExA(&execInfo))
+        {
+            win32Error = GetLastError();
+
+            spdlog::error("Failed to launch elevated {}, error {:#x}, message {}", tempFile, win32Error,
+                          winapi::GetLastErrorStdStr());
+
+            goto exit;
+        }
+
+        spdlog::debug("Elevated setup process launched successfully");
+
+        if (CancellableWait(execInfo.hProcess, stopToken) == WaitResult::Success)
+        {
+            GetExitCodeProcess(execInfo.hProcess, &exitCode);
+        }
+        else
+        {
+            exitCode = this->GetSuccessExitCode(NV_S_CLOSED_WHILE_UPDATER_RUNNING);
+        }
+        CloseHandle(execInfo.hProcess);
+    }
     else
     {
         STARTUPINFOA info = {};

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -372,6 +372,20 @@ namespace models
         }
 
         /**
+         * \brief Whether the selected release's setup should be launched elevated (As Administrator).
+         * \return True if runAsAdmin is enabled at the release or instance level, false otherwise.
+         */
+        bool RunAsAdmin()
+        {
+            if (const auto& release = GetSelectedRelease(); release.runAsAdmin.has_value())
+            {
+                return release.runAsAdmin.value();
+            }
+
+            return remote.instance.has_value() && remote.instance.value().runAsAdmin.value_or(false);
+        }
+
+        /**
          * \brief Attempts to display the UAC info dialog.
          * \param force True to ignore silent flags, false otherwise (default).
          */

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -373,16 +373,52 @@ namespace models
 
         /**
          * \brief Whether the selected release's setup should be launched elevated (As Administrator).
-         * \return True if runAsAdmin is enabled at the release or instance level, false otherwise.
+         *
+         * \remark The runAsAdmin flag is server-controlled metadata and is therefore only honoured
+         *         when the operator's configuration provides strong authenticity guarantees.
+         *         Specifically it requires either:
+         *           (a) signatureVerificationMode == Required — VerifyReleaseIntegrity() (called
+         *               before ExecuteSetup) has already enforced a valid Authenticode chain, so
+         *               the binary is guaranteed to be signed; or
+         *           (b) --strict-verification was passed on the command line — a local, non-server-
+         *               controlled opt-in that implies (a) and enforces additional checks.
+         *         In the default WhenPresent / Disabled modes the flag is silently ignored so that a
+         *         compromised server cannot trigger a UAC prompt for an unauthenticated payload.
+         *
+         * \return True only when elevation is requested AND authenticity conditions are satisfied.
          */
         bool RunAsAdmin()
         {
-            if (const auto& release = GetSelectedRelease(); release.runAsAdmin.has_value())
+            // Determine the raw flag (release-level first, then instance-level fallback).
+            const bool wantsAdmin = [&]() -> bool
             {
-                return release.runAsAdmin.value();
+                if (const auto& release = GetSelectedRelease(); release.runAsAdmin.has_value())
+                {
+                    return release.runAsAdmin.value();
+                }
+                return remote.instance.has_value() && remote.instance.value().runAsAdmin.value_or(false);
+            }();
+
+            if (!wantsAdmin)
+            {
+                return false;
             }
 
-            return remote.instance.has_value() && remote.instance.value().runAsAdmin.value_or(false);
+            // Guard: only honour the server-supplied flag when the active verification
+            // configuration mandates strong payload authenticity.
+            const bool verificationIsStrong =
+                (merged.signatureVerificationMode == SignatureVerificationMode::Required) ||
+                strictVerification;
+
+            if (!verificationIsStrong)
+            {
+                spdlog::warn("RunAsAdmin: runAsAdmin requested but signature verification mode is "
+                             "not Required and --strict-verification is not active; "
+                             "ignoring elevation request to prevent unauthenticated UAC prompt");
+                return false;
+            }
+
+            return true;
         }
 
         /**

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -31,6 +31,8 @@ namespace models
         std::optional<std::string> helpUrl;
         /** URL of the error article */
         std::optional<std::string> errorFallbackUrl;
+        /** If true, the downloaded setup is launched elevated (As Administrator) via the "runas" verb */
+        std::optional<bool> runAsAdmin;
 
         /**
          * \brief Converts the version string to a SemVer type.
@@ -55,5 +57,5 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl, errorFallbackUrl)
+      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl, errorFallbackUrl, runAsAdmin)
 }

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -99,6 +99,8 @@ namespace models
         std::optional<ZipExtractFileDisposition> zipExtractDefaultFileDisposition;
         /** Override the behavior for specific files in a zip update */
         std::optional<std::unordered_map<std::string, ZipExtractFileDisposition>> zipExtractFileDispositionOverrides;
+        /** If true, the downloaded setup is launched elevated (As Administrator) via the "runas" verb */
+        std::optional<bool> runAsAdmin;
 
         /** Full pathname of the local temporary file */
         std::filesystem::path localTempFilePath{};
@@ -135,5 +137,6 @@ namespace models
                                                     detectionSize,
                                                     detectionVersion,
                                                     zipExtractDefaultFileDisposition,
-                                                    zipExtractFileDispositionOverrides)
+                                                    zipExtractFileDispositionOverrides,
+                                                    runAsAdmin)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “run as administrator” setting for secure update releases.
  * Update setup can now be launched elevated when configured (per release or via instance preference).
  * Elevation is only honored when authenticity checks are sufficiently strict; otherwise it’s automatically disabled with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->