### PR TITLE
Version parsing hardening

### DIFF
--- a/examples/server/Endpoints/E2E/E2ESelfUpdateEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2ESelfUpdateEndpoint.cs
@@ -36,10 +36,10 @@ internal sealed class E2ESelfUpdateEndpoint : EndpointWithoutRequest
             Instance = new UpdateConfig
             {
                 // A version that will always exceed whatever the built updater's version is.
-                // Must be 3-part semver: the client parses this with semver and the updater's
-                // own version is derived as major.minor.build, so a 4-part Windows version
-                // (e.g. "999.0.0.0") fails to parse and silently disables the self-update check.
-                LatestVersion = System.Version.Parse("999.0.0"),
+                // Deliberately a 4-segment Windows-style version to exercise the client's
+                // version normalisation (GetLatestUpdaterSemVersion), which maps it onto
+                // semver instead of failing to parse.
+                LatestVersion = System.Version.Parse("999.0.0.0"),
                 LatestUrl = $"{baseUrl}/api/e2e/artifacts/updater_selfupdate.exe"
             },
             Shared = new SharedConfig

--- a/src/InstanceConfig.Template.cpp
+++ b/src/InstanceConfig.Template.cpp
@@ -468,7 +468,7 @@ std::string models::InstanceConfig::RenderInjaTemplate(const std::string& tpl, c
                              const semver::version lhs = semver::version::parse(lhsValue);
                              const semver::version rhs = semver::version::parse(rhsValue);
 
-                             return lhs == rhs;
+                             return util::CompareVersions(lhs, rhs) == 0;
                          }
                          catch (const std::exception& ex)
                          {
@@ -496,7 +496,7 @@ std::string models::InstanceConfig::RenderInjaTemplate(const std::string& tpl, c
                              const semver::version lhs = semver::version::parse(lhsValue);
                              const semver::version rhs = semver::version::parse(rhsValue);
 
-                             return lhs > rhs;
+                             return util::CompareVersions(lhs, rhs) > 0;
                          }
                          catch (const std::exception& ex)
                          {
@@ -524,7 +524,7 @@ std::string models::InstanceConfig::RenderInjaTemplate(const std::string& tpl, c
                              const semver::version lhs = semver::version::parse(lhsValue);
                              const semver::version rhs = semver::version::parse(rhsValue);
 
-                             return lhs < rhs;
+                             return util::CompareVersions(lhs, rhs) < 0;
                          }
                          catch (const std::exception& ex)
                          {

--- a/src/InstanceConfig.Template.cpp
+++ b/src/InstanceConfig.Template.cpp
@@ -468,7 +468,7 @@ std::string models::InstanceConfig::RenderInjaTemplate(const std::string& tpl, c
                              const semver::version lhs = semver::version::parse(lhsValue);
                              const semver::version rhs = semver::version::parse(rhsValue);
 
-                             return util::CompareVersions(lhs, rhs) == 0;
+                             return lhs == rhs;
                          }
                          catch (const std::exception& ex)
                          {

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -882,7 +882,7 @@ namespace
                 // top release is always latest by version, even if the response wasn't the right order
                 std::ranges::sort(remote.releases, [](const UpdateRelease& lhs, const UpdateRelease& rhs)
                 {
-                    return lhs.GetSemVersion() > rhs.GetSemVersion();
+                    return util::CompareVersions(lhs.GetSemVersion(), rhs.GetSemVersion()) > 0;
                 });
 
                 //

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -280,11 +280,27 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
         }
         else
         {
-            // A custom suffix is a SemVer pre-release/build tail; attach it to the numeric
-            // core. The revision is intentionally dropped here so the resulting string stays
-            // valid (build metadata must not precede a pre-release component).
-            std::string suffixed = std::format("{}.{}.{}{}",
-                                               fileVersion.major(), fileVersion.minor(), fileVersion.patch(), suffix);
+            // Custom suffix is a SemVer pre-release or build tail on the numeric core.
+            // Keep the Win32 revision (already in build metadata) so distinct builds
+            // do not compare equal after suffixing.
+            const std::string& revision = fileVersion.build_meta();
+            std::string suffixed;
+            if (suffix.starts_with("+"))
+            {
+                suffixed = revision.empty()
+                             ? std::format("{}.{}.{}{}", fileVersion.major(), fileVersion.minor(), fileVersion.patch(),
+                                           suffix)
+                             : std::format("{}.{}.{}+{}.{}", fileVersion.major(), fileVersion.minor(), fileVersion.patch(),
+                                           revision, suffix.substr(1));
+            }
+            else
+            {
+                suffixed = std::format("{}.{}.{}{}", fileVersion.major(), fileVersion.minor(), fileVersion.patch(), suffix);
+                if (!revision.empty())
+                {
+                    suffixed += std::format("+{}", revision);
+                }
+            }
             util::toSemVerCompatible(suffixed);
             appVersion = semver::version::parse(suffixed);
         }

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -270,7 +270,30 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
 
 #pragma endregion
 
-    appVersion = semver::version::parse(util::GetVersionFromFile(appPath).str() + NV_CUSTOM_VERSION_SUFFIX);
+    try
+    {
+        const auto fileVersion = util::GetVersionFromFile(appPath);
+        if (const std::string suffix = NV_CUSTOM_VERSION_SUFFIX; suffix.empty())
+        {
+            // Keeps the 4th (revision) segment that GetVersionFromFile stashes as build metadata.
+            appVersion = fileVersion;
+        }
+        else
+        {
+            // A custom suffix is a SemVer pre-release/build tail; attach it to the numeric
+            // core. The revision is intentionally dropped here so the resulting string stays
+            // valid (build metadata must not precede a pre-release component).
+            std::string suffixed = std::format("{}.{}.{}{}",
+                                               fileVersion.major(), fileVersion.minor(), fileVersion.patch(), suffix);
+            util::toSemVerCompatible(suffixed);
+            appVersion = semver::version::parse(suffixed);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        spdlog::error("Failed to determine app version from {}: {}", appPath.string(), e.what());
+        appVersion = semver::version{0, 0, 0};
+    }
     spdlog::debug("appVersion = {}", appVersion.str());
 
     appFilename = appPath.stem().string();
@@ -548,7 +571,8 @@ std::expected<bool, std::string> models::InstanceConfig::IsInstalledVersionOutda
                 util::toSemVerCompatible(asString);
                 const semver::version localVersion = semver::version::parse(asString);
 
-                const bool isOutdated = release.GetDetectionSemVersion() > localVersion;
+                const bool isOutdated =
+                    util::CompareVersions(release.GetDetectionSemVersion().value_or(localVersion), localVersion) > 0;
                 spdlog::debug("isOutdated = {}", isOutdated);
                 return isOutdated;
             }
@@ -617,7 +641,8 @@ std::expected<bool, std::string> models::InstanceConfig::IsInstalledVersionOutda
                 util::toSemVerCompatible(nVersion);
                 const semver::version localVersion = semver::version::parse(nVersion);
 
-                isOutdated = release.GetDetectionSemVersion() > localVersion;
+                isOutdated =
+                    util::CompareVersions(release.GetDetectionSemVersion().value_or(localVersion), localVersion) > 0;
                 spdlog::debug("isOutdated = {}", isOutdated);
             }
             catch (const std::exception& e)
@@ -655,11 +680,19 @@ std::expected<bool, std::string> models::InstanceConfig::IsInstalledVersionOutda
                 switch (cfg.statement)
                 {
                     case VersionResource::FILEVERSION:
-                        isOutdated = release.GetDetectionSemVersion() > winapi::GetWin32ResourceFileVersion(filePath);
+                    {
+                        const auto fileVer = winapi::GetWin32ResourceFileVersion(filePath);
+                        isOutdated =
+                            util::CompareVersions(release.GetDetectionSemVersion().value_or(fileVer), fileVer) > 0;
                         break;
+                    }
                     case VersionResource::PRODUCTVERSION:
-                        isOutdated = release.GetDetectionSemVersion() > winapi::GetWin32ResourceProductVersion(filePath);
+                    {
+                        const auto prodVer = winapi::GetWin32ResourceProductVersion(filePath);
+                        isOutdated =
+                            util::CompareVersions(release.GetDetectionSemVersion().value_or(prodVer), prodVer) > 0;
                         break;
+                    }
                     case VersionResource::Invalid:
                         spdlog::warn("Unexpected version resource statement");
                         isOutdated = true;

--- a/src/UpdateRelease.cpp
+++ b/src/UpdateRelease.cpp
@@ -7,8 +7,12 @@ semver::version models::UpdateRelease::GetSemVersion() const
 {
     try
     {
-        // trim whitespaces and potential "v" prefix
-        std::string value = util::trim(version, "v \t");
+        // trim whitespace, then strip a leading "v" prefix only
+        std::string value = util::trim(version);
+        if (!value.empty() && value.front() == 'v')
+        {
+            value.erase(value.begin());
+        }
         util::toSemVerCompatible(value);
 
         return semver::version::parse(value);
@@ -34,8 +38,12 @@ std::optional<semver::version> models::UpdateRelease::GetDetectionSemVersion() c
 
     try
     {
-        // trim whitespaces and potential "v" prefix
-        std::string value = util::trim(detectionVersion.value(), "v \t");
+        // trim whitespace, then strip a leading "v" prefix only
+        std::string value = util::trim(detectionVersion.value());
+        if (!value.empty() && value.front() == 'v')
+        {
+            value.erase(value.begin());
+        }
         util::toSemVerCompatible(value);
 
         return semver::version::parse(value);

--- a/src/Util.h
+++ b/src/Util.h
@@ -10,6 +10,21 @@ namespace util
     bool icompare(const std::string& a, const std::string& b);
     void toCamelCase(std::string& s);
     void toSemVerCompatible(std::string& s);
+
+    /**
+     * \brief Three-way compares two versions, honouring a 4th ("revision") segment.
+     *
+     * SemVer only models major.minor.patch(+prerelease); toSemVerCompatible() stashes
+     * the optional 4th segment of common Win32 versions (e.g. "1.2.3.4") as numeric
+     * build metadata ("1.2.3+4"). Standard SemVer precedence ignores build metadata,
+     * which would silently drop that 4th segment from comparisons. This helper applies
+     * normal SemVer precedence first and, when the core/prerelease parts are equal,
+     * breaks the tie on the numeric build metadata (a missing/non-numeric value counts
+     * as 0, so "1.2.3" and "1.2.3.0" compare equal while "1.2.3.4" outranks both).
+     *
+     * \return Negative if a precedes b, 0 if equal, positive if a succeeds b.
+     */
+    int CompareVersions(const semver::version& a, const semver::version& b);
     void stripNulls(std::string& s);
     void stripNulls(std::wstring& s);
 }

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -7,6 +7,7 @@
 #include "UpdateResponse.hpp"
 #include "MergedConfig.hpp"
 #include "NAuthenticode.h"
+#include "../Util.h"
 
 using json = nlohmann::json;
 
@@ -196,7 +197,7 @@ namespace models
 
             const auto latest = GetSelectedRelease().GetSemVersion();
 
-            return latest > currentVersion;
+            return util::CompareVersions(latest, currentVersion) > 0;
         }
 
         /**
@@ -214,7 +215,7 @@ namespace models
             {
                 const auto latest = remote.instance.value().GetLatestUpdaterSemVersion();
 
-                return latest > appVersion;
+                return util::CompareVersions(latest, appVersion) > 0;
             }
 
             return false;

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "UpdateRelease.hpp"
+#include "../Util.h"
 
 namespace models
 {
@@ -47,7 +48,13 @@ namespace models
 
             try
             {
-                return semver::version::parse(latestVersion.value());
+                // Normalise the same way release versions are handled so common
+                // Win32 forms parse cleanly: strip a leading "v"/whitespace and
+                // map 4-segment versions (e.g. "999.0.0.0") onto semver via
+                // toSemVerCompatible ("1.2.3.4" -> "1.2.3+4").
+                std::string value = util::trim(latestVersion.value(), "v \t");
+                util::toSemVerCompatible(value);
+                return semver::version::parse(value);
             }
             catch (...)  // couldn't convert version string
             {

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -49,10 +49,14 @@ namespace models
             try
             {
                 // Normalise the same way release versions are handled so common
-                // Win32 forms parse cleanly: strip a leading "v"/whitespace and
-                // map 4-segment versions (e.g. "999.0.0.0") onto semver via
+                // Win32 forms parse cleanly: trim whitespace, strip a leading "v",
+                // and map 4-segment versions (e.g. "999.0.0.0") onto semver via
                 // toSemVerCompatible ("1.2.3.4" -> "1.2.3+4").
-                std::string value = util::trim(latestVersion.value(), "v \t");
+                std::string value = util::trim(latestVersion.value());
+                if (!value.empty() && value.front() == 'v')
+                {
+                    value.erase(value.begin());
+                }
                 util::toSemVerCompatible(value);
                 return semver::version::parse(value);
             }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -42,9 +42,13 @@ namespace util
                         const auto* verInfo = (VS_FIXEDFILEINFO*)lpBuffer;
                         if (verInfo->dwSignature == 0xfeef04bd)
                         {
+                            // Emit the full 4-part Win32 version; toSemVerCompatible
+                            // maps the 4th (revision) segment onto SemVer build metadata
+                            // so CompareVersions() can still honour it.
                             versionString << static_cast<ULONG>(HIWORD(verInfo->dwProductVersionMS)) << "."
                                           << static_cast<ULONG>(LOWORD(verInfo->dwProductVersionMS)) << "."
-                                          << static_cast<ULONG>(HIWORD(verInfo->dwProductVersionLS));
+                                          << static_cast<ULONG>(HIWORD(verInfo->dwProductVersionLS)) << "."
+                                          << static_cast<ULONG>(LOWORD(verInfo->dwProductVersionLS));
                         }
                     }
                 }
@@ -52,7 +56,41 @@ namespace util
             delete[] verData;
         }
 
-        return semver::version::parse(versionString.str());
+        auto normalized = versionString.str();
+        if (normalized.empty())
+        {
+            // No usable version resource; mirror the resource-helper fallback.
+            return semver::version{0, 0, 1};
+        }
+
+        toSemVerCompatible(normalized);
+        return semver::version::parse(normalized);
+    }
+
+    int CompareVersions(const semver::version& a, const semver::version& b)
+    {
+        // Major/minor/patch and prerelease follow standard SemVer precedence.
+        if (a < b) return -1;
+        if (b < a) return 1;
+
+        // Equal so far: break the tie on the numeric build metadata, which is where
+        // toSemVerCompatible() parks the optional 4th ("revision") version segment.
+        const auto numericBuildMeta = [](const semver::version& v) -> uint64_t
+        {
+            const std::string& meta = v.build_meta();
+            if (meta.empty() || !std::ranges::all_of(meta, [](unsigned char c) { return std::isdigit(c) != 0; }))
+            {
+                return 0; // absent or non-numeric build metadata counts as revision 0
+            }
+            try { return std::stoull(meta); }
+            catch (...) { return 0; }
+        };
+
+        const uint64_t ra = numericBuildMeta(a);
+        const uint64_t rb = numericBuildMeta(b);
+        if (ra < rb) return -1;
+        if (ra > rb) return 1;
+        return 0;
     }
 
     std::expected<void, std::string> ParseCommandLineArguments(argh::parser& cmdl)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version normalization and comparison so update logic correctly recognizes newer builds, including 4-part Windows-style version numbers.
  * Made release ordering and “latest vs current” checks use consistent version comparison logic (including revision/build tie-breaking).
  * Improved parsing resilience for version strings with leading prefixes and varying segment counts.
  * Increased robustness by adding safer fallback behavior when version details can’t be read (and updated E2E coverage for self-update scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->