### PR TITLE
Added custom window and taskbar icon support

### DIFF
--- a/abstractions/docs/nefarius.vicius.abstractions.models.mergedconfig.md
+++ b/abstractions/docs/nefarius.vicius.abstractions.models.mergedconfig.md
@@ -71,6 +71,22 @@ public bool HideRemindButton { get; set; }
 
 [Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)<br>
 
+### <a id="properties-iconbase64"/>**IconBase64**
+
+Base64-encoded Windows .ico data used as the window and taskbar icon at runtime.
+
+```csharp
+public string IconBase64 { get; set; }
+```
+
+#### Property Value
+
+[String](https://learn.microsoft.com/dotnet/api/system.string)<br>
+
+**Remarks:**
+
+When set, the client decodes the .ico in memory and applies it via WM_SETICON. Absent or invalid values are silently ignored; the compiled-in icon resource is used as fallback.
+
 ### <a id="properties-installationerrorurl"/>**InstallationErrorUrl**
 
 URL pointing to a help article opening when an update error occurred.

--- a/abstractions/docs/nefarius.vicius.abstractions.models.sharedconfig.md
+++ b/abstractions/docs/nefarius.vicius.abstractions.models.sharedconfig.md
@@ -69,6 +69,22 @@ public Nullable<Boolean> HideRemindButton { get; set; }
 
 [Nullable](https://learn.microsoft.com/dotnet/api/system.nullable-1)<[Boolean](https://learn.microsoft.com/dotnet/api/system.boolean)><br>
 
+### <a id="properties-iconbase64"/>**IconBase64**
+
+Base64-encoded Windows .ico data used as the window and taskbar icon at runtime.
+
+```csharp
+public string IconBase64 { get; set; }
+```
+
+#### Property Value
+
+[String](https://learn.microsoft.com/dotnet/api/system.string)<br>
+
+**Remarks:**
+
+The server should encode a valid .ico file (which may contain a PNG-compressed entry for Vista+ compatibility) as standard Base64 and supply it here. The client decodes it in memory and applies it via WM_SETICON; the compiled-in icon is kept as fallback if the field is absent or the data cannot be decoded.
+
 ### <a id="properties-installationerrorurl"/>**InstallationErrorUrl**
 
 URL pointing to a help article opening when an update error occurred.

--- a/abstractions/src/Models/MergedConfig.cs
+++ b/abstractions/src/Models/MergedConfig.cs
@@ -104,4 +104,14 @@ public sealed class MergedConfig
     /// </summary>
     [Required]
     public bool HideRemindButton { get; set; } = false;
+
+    /// <summary>
+    ///     Base64-encoded Windows .ico data used as the window and taskbar icon at runtime.
+    /// </summary>
+    /// <remarks>
+    ///     When set, the client decodes the .ico in memory and applies it via WM_SETICON.
+    ///     Absent or invalid values are silently ignored; the compiled-in icon resource is used
+    ///     as fallback.
+    /// </remarks>
+    public string? IconBase64 { get; set; }
 }

--- a/abstractions/src/Models/SharedConfig.cs
+++ b/abstractions/src/Models/SharedConfig.cs
@@ -98,4 +98,15 @@ public sealed class SharedConfig
     ///     When true, the "Remind me tomorrow" button is hidden in the update UI.
     /// </summary>
     public bool? HideRemindButton { get; set; }
+
+    /// <summary>
+    ///     Base64-encoded Windows .ico data used as the window and taskbar icon at runtime.
+    /// </summary>
+    /// <remarks>
+    ///     The server should encode a valid .ico file (which may contain a PNG-compressed entry
+    ///     for Vista+ compatibility) as standard Base64 and supply it here.  The client decodes
+    ///     it in memory and applies it via WM_SETICON; the compiled-in icon is kept as fallback
+    ///     if the field is absent or the data cannot be decoded.
+    /// </remarks>
+    public string? IconBase64 { get; set; }
 }

--- a/examples/server/Endpoints/DefaultDemoEndpoint.cs
+++ b/examples/server/Endpoints/DefaultDemoEndpoint.cs
@@ -30,9 +30,16 @@ internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
             return string.Empty;
 
         var png = new byte[stream.Length];
-        _ = stream.Read(png, 0, png.Length);
+        stream.ReadExactly(png, 0, png.Length);
 
-        return IconConverter.PngToIcoBase64(png);
+        try
+        {
+            return IconConverter.PngToIcoBase64(png);
+        }
+        catch (ArgumentException)
+        {
+            return string.Empty;
+        }
     }
 
     public override void Configure()

--- a/examples/server/Endpoints/DefaultDemoEndpoint.cs
+++ b/examples/server/Endpoints/DefaultDemoEndpoint.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 
 using Nefarius.Vicius.Abstractions.Models;
+using Nefarius.Vicius.Example.Server.Shared;
 
 namespace Nefarius.Vicius.Example.Server.Endpoints;
 
@@ -14,6 +15,26 @@ namespace Nefarius.Vicius.Example.Server.Endpoints;
 /// </summary>
 internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
 {
+    // The server converts the PNG to a single-entry ICO (PNG-compressed, Vista+ compatible)
+    // and base64-encodes it once at startup.  The client receives a standard .ico buffer and
+    // does not need to know anything about PNG – it simply calls CreateIconFromResourceEx.
+    private static readonly string DemoIconBase64 = LoadDemoIconBase64();
+
+    private static string LoadDemoIconBase64()
+    {
+        // The PNG is embedded as a resource in server.csproj so no file-system path is needed.
+        using var stream = typeof(DefaultDemoEndpoint).Assembly
+            .GetManifestResourceStream("demo-icon.png");
+
+        if (stream is null)
+            return string.Empty;
+
+        var png = new byte[stream.Length];
+        _ = stream.Read(png, 0, png.Length);
+
+        return IconConverter.PngToIcoBase64(png);
+    }
+
     public override void Configure()
     {
         // Pointed at by the committed vcxproj.user --server-url arg.
@@ -51,6 +72,13 @@ internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
                     Version = "0.0.1"
                 },
                 // HideRemindButton intentionally left unset → "Remind me tomorrow" button is visible.
+
+                // Custom taskbar / title-bar icon.
+                // The server wraps the PNG asset in a one-entry ICO container (PNG-compressed,
+                // Windows Vista+ compatible) and base64-encodes it.  The client only ever sees a
+                // standard .ico buffer, so it stays simple.  An absent or invalid value is a
+                // silent no-op: the compiled-in icon resource is used as fallback.
+                IconBase64 = DemoIconBase64.Length > 0 ? DemoIconBase64 : null,
 
                 // Demonstrate full strict publisher-pin verification using the Microsoft-signed download.
                 // Required  → unsigned setups are rejected (chain validation is mandatory).

--- a/examples/server/Shared/IconConverter.cs
+++ b/examples/server/Shared/IconConverter.cs
@@ -30,6 +30,12 @@ internal static class IconConverter
 
         var (width, height) = ReadPngDimensions(png);
 
+        // ICONDIRENTRY bWidth/bHeight are single bytes where 0 encodes exactly 256.
+        // Values above 256 cannot be represented without truncation, so reject them explicitly.
+        if (width > 256 || height > 256)
+            throw new ArgumentException(
+                $"PNG dimensions {width}x{height} exceed the maximum ICO entry size of 256x256.", nameof(png));
+
         // ICO file layout
         // ───────────────
         // ICONDIR      (6 bytes):  reserved(2), type(2)=1, count(2)=1

--- a/examples/server/Shared/IconConverter.cs
+++ b/examples/server/Shared/IconConverter.cs
@@ -1,0 +1,83 @@
+using System.Buffers.Binary;
+
+namespace Nefarius.Vicius.Example.Server.Shared;
+
+/// <summary>
+///     Converts a PNG image to a Windows ICO file and returns it as a Base64 string,
+///     suitable for use in <see cref="Nefarius.Vicius.Abstractions.Models.SharedConfig.IconBase64" />.
+/// </summary>
+/// <remarks>
+///     Windows Vista and later support PNG-compressed entries inside .ico files, so no
+///     pixel-level re-encoding is required.  The raw PNG bytes are wrapped in the minimal
+///     ICONDIR / ICONDIRENTRY framing that the Win32 <c>CreateIconFromResourceEx</c> API
+///     expects, and then the whole thing is Base64-encoded for JSON transport.
+///     This keeps the server dependency-free while the client code path stays simple: it
+///     always deals with a standard .ico buffer, regardless of how the image was originally
+///     supplied.
+/// </remarks>
+internal static class IconConverter
+{
+    /// <summary>
+    ///     Wraps <paramref name="png" /> in a one-entry ICO container and returns the result
+    ///     as a standard Base64 string.
+    /// </summary>
+    /// <param name="png">Raw bytes of a valid PNG file.</param>
+    /// <returns>Base64-encoded .ico containing a single PNG-compressed entry.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="png" /> is not a valid PNG.</exception>
+    public static string PngToIcoBase64(byte[] png)
+    {
+        ArgumentNullException.ThrowIfNull(png);
+
+        var (width, height) = ReadPngDimensions(png);
+
+        // ICO file layout
+        // ───────────────
+        // ICONDIR      (6 bytes):  reserved(2), type(2)=1, count(2)=1
+        // ICONDIRENTRY (16 bytes): bWidth, bHeight, bColorCount, bReserved,
+        //                          wPlanes(2), wBitCount(2), dwBytesInRes(4), dwImageOffset(4)
+        // <PNG bytes>
+        const int iconDirSize  = 6;
+        const int iconEntrySize = 16;
+        const int imageOffset  = iconDirSize + iconEntrySize; // 22
+
+        var ico = new byte[imageOffset + png.Length];
+        var span = ico.AsSpan();
+
+        // ICONDIR
+        BinaryPrimitives.WriteUInt16LittleEndian(span[0..], 0);        // reserved
+        BinaryPrimitives.WriteUInt16LittleEndian(span[2..], 1);        // type = icon
+        BinaryPrimitives.WriteUInt16LittleEndian(span[4..], 1);        // count = 1
+
+        // ICONDIRENTRY
+        span[6] = (byte)(width  >= 256 ? 0 : width);   // bWidth  (0 = 256)
+        span[7] = (byte)(height >= 256 ? 0 : height);  // bHeight (0 = 256)
+        span[8] = 0;                                    // bColorCount (0 = >8 bpp)
+        span[9] = 0;                                    // bReserved
+        BinaryPrimitives.WriteUInt16LittleEndian(span[10..], 1);                       // wPlanes
+        BinaryPrimitives.WriteUInt16LittleEndian(span[12..], 32);                      // wBitCount
+        BinaryPrimitives.WriteUInt32LittleEndian(span[14..], (uint)png.Length);        // dwBytesInRes
+        BinaryPrimitives.WriteUInt32LittleEndian(span[18..], (uint)imageOffset);       // dwImageOffset
+
+        png.CopyTo(ico, imageOffset);
+
+        return Convert.ToBase64String(ico);
+    }
+
+    /// <summary>Reads width and height from the PNG IHDR chunk (big-endian uint32 at offsets 16 and 20).</summary>
+    private static (int width, int height) ReadPngDimensions(byte[] png)
+    {
+        // PNG signature: 8 bytes, then IHDR chunk: 4-byte length + 4-byte "IHDR" + 4-byte W + 4-byte H
+        const int minLength = 24;
+        if (png.Length < minLength)
+            throw new ArgumentException("Buffer is too small to be a valid PNG.", nameof(png));
+
+        // Verify PNG magic bytes: 0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
+        ReadOnlySpan<byte> magic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        if (!png.AsSpan(0, 8).SequenceEqual(magic))
+            throw new ArgumentException("Data does not start with a valid PNG signature.", nameof(png));
+
+        var width  = (int)BinaryPrimitives.ReadUInt32BigEndian(png.AsSpan(16, 4));
+        var height = (int)BinaryPrimitives.ReadUInt32BigEndian(png.AsSpan(20, 4));
+        return (width, height);
+    }
+}

--- a/examples/server/server.csproj
+++ b/examples/server/server.csproj
@@ -21,6 +21,13 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Demo icon: NSS-128x128.png wrapped server-side into a PNG-in-ICO for IconBase64 -->
+        <EmbeddedResource Include="..\..\assets\NSS-128x128.png">
+            <LogicalName>demo-icon.png</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
+
+    <ItemGroup>
         <TrimmerRootAssembly Include="System.IO.FileSystem" />
         <TrimmerRootAssembly Include="System.Xml.XPath.XDocument" />
         <TrimmerRootAssembly Include="System.Xml.Linq" />

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -985,6 +985,8 @@ namespace
                         merged.signatureConfig = shared.signatureConfig.value();
 
                     if (shared.hideRemindButton.has_value()) merged.hideRemindButton = shared.hideRemindButton.value();
+
+                    if (shared.iconBase64.has_value()) merged.iconBase64 = shared.iconBase64.value();
                 }
 
                 return {};

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -109,7 +109,7 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
         this->channel = cmdl(NV_CLI_PARAM_CHANNEL).str();
     }
 
-    spdlog::debug("channel = {}", channel);
+    spdlog::debug("channel = `{}`", channel);
 
     this->appPath = util::GetImageBasePathW();
     spdlog::debug("appPath = {}", appPath);
@@ -589,24 +589,27 @@ void models::InstanceConfig::ApplyCustomWindowIcon(HWND hWnd)
 
     spdlog::debug("Custom icon: requesting big {}x{}, small {}x{}", bigCx, bigCy, smCx, smCy);
 
-    const auto bigIcon = winapi::CreateIconFromIcoBuffer(*decoded, bigCx, bigCy);
-    if (!bigIcon)
+    // Helper: create one icon size, log the outcome, and return the result.
+    const auto makeIcon = [&](int cx, int cy, std::string_view label) -> std::expected<HICON, std::string>
     {
-        spdlog::warn("Custom icon: failed to create big icon ({}x{}): {}", bigCx, bigCy, bigIcon.error());
-        return;
-    }
+        auto result = winapi::CreateIconFromIcoBuffer(*decoded, cx, cy);
+        if (!result)
+            spdlog::warn("Custom icon: failed to create {} icon ({}x{}): {}", label, cx, cy, result.error());
+        else
+            spdlog::debug("Custom icon: {} HICON={} created", label, static_cast<void*>(*result));
+        return result;
+    };
 
-    spdlog::debug("Custom icon: big HICON={} created", static_cast<void*>(*bigIcon));
+    const auto bigIcon = makeIcon(bigCx, bigCy, "big");
+    if (!bigIcon) return;
 
-    const auto smIcon = winapi::CreateIconFromIcoBuffer(*decoded, smCx, smCy);
-    if (!smIcon)
-    {
-        spdlog::warn("Custom icon: failed to create small icon ({}x{}): {}", smCx, smCy, smIcon.error());
-        DestroyIcon(*bigIcon);
-        return;
-    }
+    const auto smIcon = makeIcon(smCx, smCy, "small");
+    if (!smIcon) { DestroyIcon(*bigIcon); return; }
 
-    spdlog::debug("Custom icon: small HICON={} created", static_cast<void*>(*smIcon));
+    // Release any previously stored handles before overwriting, so re-invocation
+    // does not leak GDI/USER resources.
+    if (customIconBig)   { DestroyIcon(customIconBig);   customIconBig   = nullptr; }
+    if (customIconSmall) { DestroyIcon(customIconSmall); customIconSmall = nullptr; }
 
     // Store handles so we can DestroyIcon them in the destructor.
     customIconBig   = *bigIcon;

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -559,8 +559,71 @@ models::InstanceConfig::~InstanceConfig()
         }
     }
 
+    if (customIconBig)   { DestroyIcon(customIconBig);   customIconBig   = nullptr; }
+    if (customIconSmall) { DestroyIcon(customIconSmall); customIconSmall = nullptr; }
+
     // make sure everything ends up on file before shutting down
     spdlog::default_logger()->flush();
+}
+
+void models::InstanceConfig::ApplyCustomWindowIcon(HWND hWnd)
+{
+    if (!merged.iconBase64.has_value() || merged.iconBase64->empty())
+        return;
+
+    spdlog::debug("Custom icon: decoding {} base64 characters", merged.iconBase64->size());
+
+    const auto decoded = winapi::DecodeBase64(*merged.iconBase64);
+    if (!decoded)
+    {
+        spdlog::warn("Custom icon: base64 decode failed: {}", decoded.error());
+        return;
+    }
+
+    spdlog::debug("Custom icon: decoded {} bytes of ICO data", decoded->size());
+
+    const int bigCx  = GetSystemMetrics(SM_CXICON);
+    const int bigCy  = GetSystemMetrics(SM_CYICON);
+    const int smCx   = GetSystemMetrics(SM_CXSMICON);
+    const int smCy   = GetSystemMetrics(SM_CYSMICON);
+
+    spdlog::debug("Custom icon: requesting big {}x{}, small {}x{}", bigCx, bigCy, smCx, smCy);
+
+    const auto bigIcon = winapi::CreateIconFromIcoBuffer(*decoded, bigCx, bigCy);
+    if (!bigIcon)
+    {
+        spdlog::warn("Custom icon: failed to create big icon ({}x{}): {}", bigCx, bigCy, bigIcon.error());
+        return;
+    }
+
+    spdlog::debug("Custom icon: big HICON={} created", static_cast<void*>(*bigIcon));
+
+    const auto smIcon = winapi::CreateIconFromIcoBuffer(*decoded, smCx, smCy);
+    if (!smIcon)
+    {
+        spdlog::warn("Custom icon: failed to create small icon ({}x{}): {}", smCx, smCy, smIcon.error());
+        DestroyIcon(*bigIcon);
+        return;
+    }
+
+    spdlog::debug("Custom icon: small HICON={} created", static_cast<void*>(*smIcon));
+
+    // Store handles so we can DestroyIcon them in the destructor.
+    customIconBig   = *bigIcon;
+    customIconSmall = *smIcon;
+
+    // Apply to the window (title bar) and the window class (taskbar/Alt+Tab).
+    SendMessageW(hWnd, WM_SETICON, ICON_BIG,   reinterpret_cast<LPARAM>(customIconBig));
+    spdlog::debug("Custom icon: WM_SETICON ICON_BIG sent");
+
+    SendMessageW(hWnd, WM_SETICON, ICON_SMALL,  reinterpret_cast<LPARAM>(customIconSmall));
+    spdlog::debug("Custom icon: WM_SETICON ICON_SMALL sent");
+
+    SetClassLongPtrW(hWnd, GCLP_HICON,   reinterpret_cast<LONG_PTR>(customIconBig));
+    SetClassLongPtrW(hWnd, GCLP_HICONSM, reinterpret_cast<LONG_PTR>(customIconSmall));
+    spdlog::debug("Custom icon: class icons updated (GCLP_HICON + GCLP_HICONSM)");
+
+    spdlog::debug("Custom icon: successfully applied (big {}x{}, small {}x{})", bigCx, bigCy, smCx, smCy);
 }
 
 std::expected<bool, std::string> models::InstanceConfig::IsInstalledVersionOutdated()

--- a/src/Util.h
+++ b/src/Util.h
@@ -120,4 +120,27 @@ namespace winapi
      *        WM_SETTINGCHANGE (ImmersiveColorSet) and WM_DWMCOLORIZATIONCOLORCHANGED.
      */
     void InvalidateAccentColorCache();
+
+    /**
+     * \brief Decodes a standard Base64 string into raw bytes using CryptStringToBinaryA.
+     * \param b64 The Base64-encoded input string.
+     * \return Decoded bytes on success; unexpected error string on failure.
+     * \remarks Rejects inputs larger than 1 MiB as a safety guard against server-supplied data.
+     */
+    [[nodiscard]] std::expected<std::vector<uint8_t>, std::string> DecodeBase64(const std::string& b64);
+
+    /**
+     * \brief Creates an HICON from an in-memory Windows .ico buffer.
+     *
+     * Validates the ICONDIR/ICONDIRENTRY structure, picks the best-matching entry for
+     * the requested dimensions and delegates to CreateIconFromResourceEx so both
+     * legacy BMP-compressed and Vista+ PNG-compressed icon entries are supported.
+     *
+     * \param ico  Raw bytes of a valid .ico file.
+     * \param cx   Desired icon width  (e.g. GetSystemMetrics(SM_CXICON)).
+     * \param cy   Desired icon height (e.g. GetSystemMetrics(SM_CYICON)).
+     * \return A valid HICON on success; unexpected error string on failure.
+     * \remarks The caller is responsible for calling DestroyIcon on the returned handle.
+     */
+    [[nodiscard]] std::expected<HICON, std::string> CreateIconFromIcoBuffer(const std::vector<uint8_t>& ico, int cx, int cy);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -447,6 +447,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     }
 
     cfg.SetWindowHandle(hwnd);
+    cfg.ApplyCustomWindowIcon(hwnd);
 
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -112,6 +112,11 @@ namespace models
         /** True if the updater exe itself carries a valid Authenticode signature */
         bool isUpdaterSigned{false};
 
+        /** Custom window/taskbar icon (big), created from merged.iconBase64; freed in dtor */
+        HICON customIconBig{};
+        /** Custom window/taskbar icon (small), created from merged.iconBase64; freed in dtor */
+        HICON customIconSmall{};
+
         std::expected<int, std::string> DownloadRelease(curl_progress_callback progressFn, int releaseIndex);
 
         [[nodiscard]] std::list<std::string> BuildCommonHeaders() const;
@@ -143,6 +148,16 @@ namespace models
         ~InstanceConfig();
 
         void SetWindowHandle(_In_ const HWND hWnd) { windowHandle = hWnd; }
+
+        /**
+         * \brief Decodes merged.iconBase64 and sets it as the window and taskbar icon.
+         *
+         * No-op when iconBase64 is absent or empty. On any decode or Win32 failure the
+         * warning is logged and the compiled-in icon resource remains in effect.
+         *
+         * \param hWnd The main application window handle.
+         */
+        void ApplyCustomWindowIcon(HWND hWnd);
 
         std::filesystem::path GetAppPath() const { return appPath; }
         semver::version GetAppVersion() const { return appVersion; }

--- a/src/models/MergedConfig.hpp
+++ b/src/models/MergedConfig.hpp
@@ -39,6 +39,8 @@ namespace models
         std::optional<SignatureConfig> signatureConfig;
         /** True to hide the "Remind me tomorrow" button in the UI */
         bool hideRemindButton{false};
+        /** Base64-encoded Windows .ico data for the window and taskbar icon */
+        std::optional<std::string> iconBase64;
 
         MergedConfig() : windowTitle(NV_WINDOW_TITLE), productName(NV_PRODUCT_NAME) { }
 
@@ -67,5 +69,6 @@ namespace models
                                                     signaturePolicy,
                                                     signatureStrategy,
                                                     signatureConfig,
-                                                    hideRemindButton)
+                                                    hideRemindButton,
+                                                    iconBase64)
 }

--- a/src/models/SharedConfig.hpp
+++ b/src/models/SharedConfig.hpp
@@ -39,6 +39,8 @@ namespace models
         std::optional<SignatureConfig> signatureConfig;
         /** True to hide the "Remind me tomorrow" button in the UI */
         std::optional<bool> hideRemindButton;
+        /** Base64-encoded Windows .ico data for the window and taskbar icon */
+        std::optional<std::string> iconBase64;
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(SharedConfig,
@@ -53,5 +55,6 @@ namespace models
                                                     signaturePolicy,
                                                     signatureStrategy,
                                                     signatureConfig,
-                                                    hideRemindButton)
+                                                    hideRemindButton,
+                                                    iconBase64)
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -770,19 +770,20 @@ namespace winapi
         if (ico.size() < kIconDirSize)
             return std::unexpected("ICO buffer too small for ICONDIR header");
 
-        const auto* dir = reinterpret_cast<const ICONDIR*>(ico.data());
+        // Use memcpy into local structs to avoid unaligned pointer-cast UB; the
+        // #pragma pack(1) structs have the right field layout and sizeof() values.
+        ICONDIR dir{};
+        std::memcpy(&dir, ico.data(), kIconDirSize);
 
-        if (dir->idReserved != 0 || dir->idType != 1)
+        if (dir.idReserved != 0 || dir.idType != 1)
             return std::unexpected("ICO buffer has invalid ICONDIR signature");
 
-        if (dir->idCount == 0)
+        if (dir.idCount == 0)
             return std::unexpected("ICO buffer contains no entries");
 
-        const size_t entriesEnd = kIconDirSize + static_cast<size_t>(dir->idCount) * kEntrySize;
+        const size_t entriesEnd = kIconDirSize + static_cast<size_t>(dir.idCount) * kEntrySize;
         if (ico.size() < entriesEnd)
             return std::unexpected("ICO buffer too small for ICONDIRENTRY table");
-
-        const auto* entries = reinterpret_cast<const ICONDIRENTRY*>(ico.data() + kIconDirSize);
 
         // Pick the entry whose dimensions are closest to the requested size.
         // For entries with bWidth/bHeight == 0, the actual size is 256.
@@ -791,9 +792,10 @@ namespace winapi
         int bestDelta = INT_MAX;
         WORD bestBitCount = 0;
 
-        for (int i = 0; i < static_cast<int>(dir->idCount); ++i)
+        for (int i = 0; i < static_cast<int>(dir.idCount); ++i)
         {
-            const ICONDIRENTRY& e = entries[i];
+            ICONDIRENTRY e{};
+            std::memcpy(&e, ico.data() + kIconDirSize + static_cast<size_t>(i) * kEntrySize, kEntrySize);
 
             // Validate this entry's data range fits inside the buffer.
             const size_t entryEnd = static_cast<size_t>(e.dwImageOffset) + e.dwBytesInRes;
@@ -815,7 +817,8 @@ namespace winapi
         if (bestIdx < 0)
             return std::unexpected("ICO buffer has no valid entries");
 
-        const ICONDIRENTRY& best = entries[bestIdx];
+        ICONDIRENTRY best{};
+        std::memcpy(&best, ico.data() + kIconDirSize + static_cast<size_t>(bestIdx) * kEntrySize, kEntrySize);
         const BYTE* imgData = ico.data() + best.dwImageOffset;
 
         HICON hIcon = CreateIconFromResourceEx(

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -708,4 +708,127 @@ namespace winapi
     {
         g_accentCache.valid = false;
     }
+
+    std::expected<std::vector<uint8_t>, std::string> DecodeBase64(const std::string& b64)
+    {
+        constexpr size_t maxInputBytes = 1u * 1024u * 1024u; // 1 MiB guard
+        if (b64.size() > maxInputBytes)
+            return std::unexpected("Base64 input exceeds 1 MiB limit");
+
+        if (b64.empty())
+            return std::unexpected("Base64 input is empty");
+
+        DWORD decodedLen = 0;
+        if (!CryptStringToBinaryA(b64.c_str(), static_cast<DWORD>(b64.size()),
+                                  CRYPT_STRING_BASE64, nullptr, &decodedLen, nullptr, nullptr))
+        {
+            return std::unexpected(std::format("CryptStringToBinaryA (size query) failed: {:#x}", GetLastError()));
+        }
+
+        std::vector<uint8_t> out(decodedLen);
+        if (!CryptStringToBinaryA(b64.c_str(), static_cast<DWORD>(b64.size()),
+                                  CRYPT_STRING_BASE64, out.data(), &decodedLen, nullptr, nullptr))
+        {
+            return std::unexpected(std::format("CryptStringToBinaryA (decode) failed: {:#x}", GetLastError()));
+        }
+
+        out.resize(decodedLen);
+        return out;
+    }
+
+    std::expected<HICON, std::string> CreateIconFromIcoBuffer(const std::vector<uint8_t>& ico, int cx, int cy)
+    {
+        // ICO file layout:
+        //   ICONDIR  (6 bytes): reserved(2), type(2)=1, count(2)
+        //   ICONDIRENTRY[count] (16 bytes each):
+        //     bWidth(1), bHeight(1), bColorCount(1), bReserved(1),
+        //     wPlanes(2), wBitCount(2), dwBytesInRes(4), dwImageOffset(4)
+
+#pragma pack(push, 1)
+        struct ICONDIR
+        {
+            WORD idReserved;
+            WORD idType;
+            WORD idCount;
+        };
+        struct ICONDIRENTRY
+        {
+            BYTE  bWidth;
+            BYTE  bHeight;
+            BYTE  bColorCount;
+            BYTE  bReserved;
+            WORD  wPlanes;
+            WORD  wBitCount;
+            DWORD dwBytesInRes;
+            DWORD dwImageOffset;
+        };
+#pragma pack(pop)
+
+        constexpr size_t kIconDirSize  = sizeof(ICONDIR);
+        constexpr size_t kEntrySize    = sizeof(ICONDIRENTRY);
+
+        if (ico.size() < kIconDirSize)
+            return std::unexpected("ICO buffer too small for ICONDIR header");
+
+        const auto* dir = reinterpret_cast<const ICONDIR*>(ico.data());
+
+        if (dir->idReserved != 0 || dir->idType != 1)
+            return std::unexpected("ICO buffer has invalid ICONDIR signature");
+
+        if (dir->idCount == 0)
+            return std::unexpected("ICO buffer contains no entries");
+
+        const size_t entriesEnd = kIconDirSize + static_cast<size_t>(dir->idCount) * kEntrySize;
+        if (ico.size() < entriesEnd)
+            return std::unexpected("ICO buffer too small for ICONDIRENTRY table");
+
+        const auto* entries = reinterpret_cast<const ICONDIRENTRY*>(ico.data() + kIconDirSize);
+
+        // Pick the entry whose dimensions are closest to the requested size.
+        // For entries with bWidth/bHeight == 0, the actual size is 256.
+        // Break ties by preferring higher bit depth.
+        int bestIdx = -1;
+        int bestDelta = INT_MAX;
+        WORD bestBitCount = 0;
+
+        for (int i = 0; i < static_cast<int>(dir->idCount); ++i)
+        {
+            const ICONDIRENTRY& e = entries[i];
+
+            // Validate this entry's data range fits inside the buffer.
+            const size_t entryEnd = static_cast<size_t>(e.dwImageOffset) + e.dwBytesInRes;
+            if (e.dwBytesInRes == 0 || entryEnd > ico.size())
+                continue;
+
+            const int w = e.bWidth  == 0 ? 256 : e.bWidth;
+            const int h = e.bHeight == 0 ? 256 : e.bHeight;
+            const int delta = std::abs(w - cx) + std::abs(h - cy);
+
+            if (delta < bestDelta || (delta == bestDelta && e.wBitCount > bestBitCount))
+            {
+                bestIdx      = i;
+                bestDelta    = delta;
+                bestBitCount = e.wBitCount;
+            }
+        }
+
+        if (bestIdx < 0)
+            return std::unexpected("ICO buffer has no valid entries");
+
+        const ICONDIRENTRY& best = entries[bestIdx];
+        const BYTE* imgData = ico.data() + best.dwImageOffset;
+
+        HICON hIcon = CreateIconFromResourceEx(
+            const_cast<PBYTE>(imgData),
+            best.dwBytesInRes,
+            TRUE,
+            0x00030000, // ICO version 3.0
+            cx, cy,
+            LR_DEFAULTCOLOR);
+
+        if (!hIcon)
+            return std::unexpected(std::format("CreateIconFromResourceEx failed: {:#x}", GetLastError()));
+
+        return hIcon;
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable custom app icon supplied as Base64-encoded Windows `.ico` data.
  * The app can now apply this icon at runtime for the window and taskbar, with a built-in icon used as fallback when missing or invalid.
  * Updated the server example to generate and send a custom icon automatically.
* **Documentation**
  * Expanded configuration docs to describe the new icon setting and its runtime behavior and fallback logic.
* **Bug Fixes**
  * Improved custom icon handling to avoid stale icon state during shutdown/reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->