### PR TITLE
Added Updater Network Resilience

### DIFF
--- a/abstractions/src/Models/InstanceConfig.cs
+++ b/abstractions/src/Models/InstanceConfig.cs
@@ -31,7 +31,7 @@ public enum Authority
 ///     Local configuration file model (the fields written to the embedded JSON resource of each updater binary).
 /// </summary>
 /// <remarks>
-///     Only the four fields present in the C++ <c>NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT</c> macro are
+///     Only the fields present in the C++ <c>NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT</c> macro are
 ///     included here. Runtime-only members of <c>InstanceConfig</c> are not serialized and are therefore excluded.
 /// </remarks>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
@@ -61,4 +61,10 @@ public sealed class InstanceConfig
     /// </summary>
     [Required]
     public Authority Authority { get; set; } = Authority.Remote;
+
+    /// <summary>
+    ///     Optional network resilience settings. When absent, the updater uses sensible defaults:
+    ///     system proxy auto-detect, standard DNS, no pinned hosts.
+    /// </summary>
+    public NetworkConfig? Network { get; set; }
 }

--- a/abstractions/src/Models/NetworkConfig.cs
+++ b/abstractions/src/Models/NetworkConfig.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Nefarius.Vicius.Abstractions.Models;
+
+/// <summary>
+///     Controls how the updater obtains an HTTP proxy for outbound connections.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum ProxyMode
+{
+    /// <summary>
+    ///     Auto-detect from the Windows/WinINET system proxy settings (static proxy, PAC URL, or WPAD).
+    ///     This is the default; the updater will work behind corporate firewalls without any configuration.
+    /// </summary>
+    [EnumMember(Value = nameof(System))]
+    System,
+
+    /// <summary>
+    ///     Always connect directly — no proxy, even if one is configured in the OS.
+    /// </summary>
+    [EnumMember(Value = nameof(None))]
+    None,
+
+    /// <summary>
+    ///     Use the explicit URL specified in <see cref="NetworkConfig.ProxyUrl" />.
+    /// </summary>
+    [EnumMember(Value = nameof(Manual))]
+    Manual
+}
+
+/// <summary>
+///     Controls which IP address family libcurl uses for name resolution.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum IpFamily
+{
+    /// <summary>
+    ///     Let libcurl choose (default).
+    /// </summary>
+    [EnumMember(Value = nameof(Any))]
+    Any,
+
+    /// <summary>
+    ///     Force IPv4 name resolution. Useful when IPv6 connectivity is unreliable.
+    /// </summary>
+    [EnumMember(Value = nameof(V4))]
+    V4,
+
+    /// <summary>
+    ///     Force IPv6 name resolution.
+    /// </summary>
+    [EnumMember(Value = nameof(V6))]
+    V6
+}
+
+/// <summary>
+///     A static host→IP pin that bypasses DNS for a specific hostname.
+/// </summary>
+/// <remarks>
+///     The SNI hostname in TLS is still taken from the URL, so the server's TLS certificate must
+///     match the hostname. Useful when DNS is blocked or poisoned but the IP address is reachable.
+/// </remarks>
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+public sealed class PinnedHost
+{
+    /// <summary>
+    ///     Hostname to pin, e.g. <c>vicius.api.nefarius.systems</c>.
+    /// </summary>
+    public required string Host { get; set; }
+
+    /// <summary>
+    ///     Port number to pin. Defaults to <c>443</c>.
+    /// </summary>
+    public int Port { get; set; } = 443;
+
+    /// <summary>
+    ///     IP address to use instead of DNS, e.g. <c>104.21.0.1</c>. May be IPv4 or IPv6.
+    /// </summary>
+    public required string Address { get; set; }
+}
+
+/// <summary>
+///     Per-deployment network resilience configuration read from the sidecar JSON under
+///     <c>instance.network</c>. All fields are optional; sensible defaults apply when absent.
+/// </summary>
+/// <example>
+/// <code lang="json">
+/// {
+///   "instance": {
+///     "network": {
+///       "proxyMode": "System",
+///       "proxyUrl": "http://user:pass@proxy.corp:8080",
+///       "dohUrl": "https://cloudflare-dns.com/dns-query",
+///       "ipFamily": "Any",
+///       "pinnedHosts": [
+///         { "host": "vicius.api.nefarius.systems", "port": 443, "address": "104.21.0.1" }
+///       ]
+///     }
+///   }
+/// }
+/// </code>
+/// </example>
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+public sealed class NetworkConfig
+{
+    /// <summary>
+    ///     How the updater should obtain an HTTP proxy. Defaults to <see cref="ProxyMode.System" />
+    ///     (auto-detect from Windows/WinINET settings).
+    /// </summary>
+    public ProxyMode ProxyMode { get; set; } = ProxyMode.System;
+
+    /// <summary>
+    ///     Explicit proxy URL used when <see cref="ProxyMode" /> is <see cref="ProxyMode.Manual" />.
+    ///     Format: <c>http[s]://[user:pass@]host:port</c>
+    /// </summary>
+    public string? ProxyUrl { get; set; }
+
+    /// <summary>
+    ///     DNS-over-HTTPS resolver URL. When non-empty, libcurl uses DoH for all name resolutions,
+    ///     bypassing the system resolver. Useful against DNS censorship or poisoning.
+    ///     Example: <c>https://cloudflare-dns.com/dns-query</c>
+    /// </summary>
+    public string? DohUrl { get; set; }
+
+    /// <summary>
+    ///     IP address family preference for DNS resolution. Defaults to <see cref="IpFamily.Any" />.
+    ///     Set to <see cref="IpFamily.V4" /> or <see cref="IpFamily.V6" /> to force a specific family.
+    /// </summary>
+    public IpFamily IpFamily { get; set; } = IpFamily.Any;
+
+    /// <summary>
+    ///     Static host→IP pin entries. For each entry the updater bypasses DNS and connects directly
+    ///     to the pinned IP address, while still using the hostname in TLS SNI.
+    /// </summary>
+    public List<PinnedHost>? PinnedHosts { get; set; }
+}

--- a/abstractions/src/Models/UpdateConfig.cs
+++ b/abstractions/src/Models/UpdateConfig.cs
@@ -29,6 +29,12 @@ public sealed class UpdateConfig
     public string? LatestUrl { get; set; }
 
     /// <summary>
+    ///     Optional list of mirror/fallback URLs for the self-updater binary, tried in order when
+    ///     <see cref="LatestUrl" /> is unreachable. All URLs must use HTTPS.
+    /// </summary>
+    public List<string>? LatestMirrorUrls { get; set; }
+
+    /// <summary>
     ///     Optional checksum of the self-updater binary at <see cref="LatestUrl" />.
     ///     Passed to the self-updater DLL so it can verify the download before swapping.
     /// </summary>

--- a/abstractions/src/Models/UpdateRelease.cs
+++ b/abstractions/src/Models/UpdateRelease.cs
@@ -91,6 +91,12 @@ public sealed class UpdateRelease
     public required string DownloadUrl { get; set; } = null!;
 
     /// <summary>
+    ///     Optional list of mirror/alternative download URLs tried in order when <see cref="DownloadUrl" /> is
+    ///     unreachable (e.g. blocked by a firewall or censorship). All URLs must use HTTPS.
+    /// </summary>
+    public List<string>? MirrorUrls { get; set; }
+
+    /// <summary>
     ///     Optional size (in bytes) of the download target. If this is not set, the UI will display "N/A" until download
     ///     starts.
     /// </summary>

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -310,6 +310,8 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
     // Optional network resilience params forwarded by RunSelfUpdater.
     const std::string proxyUrl  = cmdl({"--proxy"}).str();
     const std::string dohUrl    = cmdl({"--doh-url"}).str();
+    // --no-proxy signals ProxyMode::None: forces direct connection, overrides any env-var proxy.
+    const bool noProxy = cmdl[{"--no-proxy"}];
 
     int pid;
     if (!(cmdl({"--pid"}) >> pid))
@@ -480,9 +482,6 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
                     break;
                 }
 
-                // CURLOPT_RESOLVE slist (must outlive perform()).
-                curl_slist* resolveList = nullptr;
-
                 try
                 {
                     curlpp::Easy req;
@@ -494,6 +493,8 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
 
                     if (!proxyUrl.empty())
                         req.setOpt(curlpp::options::Proxy(proxyUrl));
+                    else if (noProxy)
+                        req.setOpt(curlpp::options::Proxy(std::string{})); // force direct, suppress env-var proxy
 
                     if (!dohUrl.empty())
                         curl_easy_setopt(req.getHandle(), CURLOPT_DOH_URL, dohUrl.c_str());
@@ -510,15 +511,29 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
 
                     req.perform();
 
-                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
-                    outStream.close();
-                    downloadOk = true;
-                    spdlog::info("Download finished from {}", candidateUrl);
-                    break; // success — exit attempt loop
+                    // libcurl does not throw on HTTP error codes — check explicitly.
+                    long httpCode = 0;
+                    curl_easy_getinfo(req.getHandle(), CURLINFO_RESPONSE_CODE, &httpCode);
+
+                    try { outStream.close(); } catch (...) {}
+
+                    if (httpCode >= 400)
+                    {
+                        spdlog::error("Download attempt {}/{} from {} returned HTTP {}",
+                                      attempt + 1, kMaxRetries, candidateUrl, httpCode);
+                        if (attempt + 1 < kMaxRetries)
+                            Sleep(2000);
+                        // downloadOk stays false; attempt loop continues
+                    }
+                    else
+                    {
+                        downloadOk = true;
+                        spdlog::info("Download finished from {}", candidateUrl);
+                        break; // success — exit attempt loop
+                    }
                 }
                 catch (const curlpp::RuntimeError& e)
                 {
-                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
                     try { outStream.close(); } catch (...) {}
                     spdlog::error("Download attempt {}/{} from {} failed: {}", attempt + 1, kMaxRetries, candidateUrl, e.what());
                     if (attempt + 1 < kMaxRetries)
@@ -526,7 +541,6 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
                 }
                 catch (...)
                 {
-                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
                     try { outStream.close(); } catch (...) {}
                     spdlog::error("Download attempt {}/{} from {} failed with unknown error", attempt + 1, kMaxRetries, candidateUrl);
                     if (attempt + 1 < kMaxRetries)

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -246,8 +246,14 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
         "--path",          // the target file path
         "--checksum",      // expected SHA256 hex digest of downloaded file
         "--checksum-alg",  // checksum algorithm: sha256 (default), sha1
-        "--log-level"
+        "--log-level",
+        "--proxy",         // explicit proxy URL, e.g. "http://proxy.corp:8080"
+        "--doh-url",       // DNS-over-HTTPS resolver URL
     });
+
+    // --mirror-url is multi-value; collect all occurrences after parsing
+    // (argh does not natively support repeated params, so we scan argv manually)
+    cmdl.add_params({"--mirror-url"});
 
     // we now have the same format as a classic main argv to parse
     cmdl.parse(nArgs, argv.data());
@@ -291,6 +297,19 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
         spdlog::critical("--url parameter missing");
         return;
     }
+
+    // Collect all --mirror-url values by scanning argv manually (argh returns only
+    // the last occurrence for repeated params).
+    std::vector<std::string> mirrorUrls;
+    for (int i = 0; i < nArgs - 1; ++i)
+    {
+        if (narrow[i] == "--mirror-url")
+            mirrorUrls.push_back(narrow[i + 1]);
+    }
+
+    // Optional network resilience params forwarded by RunSelfUpdater.
+    const std::string proxyUrl  = cmdl({"--proxy"}).str();
+    const std::string dohUrl    = cmdl({"--doh-url"}).str();
 
     int pid;
     if (!(cmdl({"--pid"}) >> pid))
@@ -383,7 +402,13 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
     }
     while (hProcess);
 
-    spdlog::debug("Preparing download to temp file");
+    // Build ordered download candidate list: primary URL first, then mirrors.
+    std::vector<std::string> candidateUrls;
+    candidateUrls.push_back(url);
+    for (const auto& m : mirrorUrls)
+        candidateUrls.push_back(m);
+
+    spdlog::debug("Self-updater has {} download candidate(s)", candidateUrls.size());
 
     std::ofstream outStream;
     const std::ios_base::iostate exceptionMask = outStream.exceptions() | std::ios::failbit;
@@ -432,11 +457,99 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
         SetFileAttributesA(backupFile.c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM);
         spdlog::debug("Moved original {} to backup {}", original.string(), backupFile);
 
-        // Download to the separate temp file (NOT the original location yet)
-        spdlog::info("Downloading {} to {}", url, downloadFile);
-        outStream.open(downloadPath, std::ios::binary | std::ofstream::ate);
-        outStream << curlpp::options::Url(url);
-        outStream.close();
+        // Download to the separate temp file, trying each candidate URL in turn.
+        bool downloadOk = false;
+        for (size_t urlIdx = 0; urlIdx < candidateUrls.size(); ++urlIdx)
+        {
+            const auto& candidateUrl = candidateUrls[urlIdx];
+            spdlog::info("Downloading {} to {} (candidate {}/{})",
+                         candidateUrl, downloadFile, urlIdx + 1, candidateUrls.size());
+
+            constexpr int kMaxRetries = 3;
+            for (int attempt = 0; attempt < kMaxRetries; ++attempt)
+            {
+                // Truncate the temp file before each attempt.
+                try
+                {
+                    if (outStream.is_open()) outStream.close();
+                    outStream.open(downloadPath, std::ios::binary | std::ios::trunc);
+                }
+                catch (...)
+                {
+                    spdlog::error("Failed to open temp file for writing");
+                    break;
+                }
+
+                // CURLOPT_RESOLVE slist (must outlive perform()).
+                curl_slist* resolveList = nullptr;
+
+                try
+                {
+                    curlpp::Easy req;
+                    req.setOpt(curlpp::options::Url(candidateUrl));
+                    req.setOpt(curlpp::options::FollowLocation(true));
+                    req.setOpt(curlpp::options::ConnectTimeout(60L));
+                    req.setOpt(curlpp::options::LowSpeedLimit(1L));
+                    req.setOpt(curlpp::options::LowSpeedTime(300L)); // 5 min stall timeout
+
+                    if (!proxyUrl.empty())
+                        req.setOpt(curlpp::options::Proxy(proxyUrl));
+
+                    if (!dohUrl.empty())
+                        curl_easy_setopt(req.getHandle(), CURLOPT_DOH_URL, dohUrl.c_str());
+
+                    // Stream body directly to file
+                    auto writeCallback = [&](char* ptr, size_t size, size_t nmemb) -> size_t
+                    {
+                        const size_t bytes = size * nmemb;
+                        if (ptr == nullptr || bytes == 0) return bytes;
+                        try { outStream.write(ptr, static_cast<std::streamsize>(bytes)); return bytes; }
+                        catch (...) { return 0; }
+                    };
+                    req.setOpt(curlpp::options::WriteFunction(writeCallback));
+
+                    req.perform();
+
+                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
+                    outStream.close();
+                    downloadOk = true;
+                    spdlog::info("Download finished from {}", candidateUrl);
+                    break; // success — exit attempt loop
+                }
+                catch (const curlpp::RuntimeError& e)
+                {
+                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
+                    try { outStream.close(); } catch (...) {}
+                    spdlog::error("Download attempt {}/{} from {} failed: {}", attempt + 1, kMaxRetries, candidateUrl, e.what());
+                    if (attempt + 1 < kMaxRetries)
+                        Sleep(2000);
+                }
+                catch (...)
+                {
+                    if (resolveList) { curl_slist_free_all(resolveList); resolveList = nullptr; }
+                    try { outStream.close(); } catch (...) {}
+                    spdlog::error("Download attempt {}/{} from {} failed with unknown error", attempt + 1, kMaxRetries, candidateUrl);
+                    if (attempt + 1 < kMaxRetries)
+                        Sleep(2000);
+                }
+            }
+
+            if (downloadOk)
+                break; // exit mirror loop
+
+            spdlog::warn("All attempts failed for candidate {}, trying next mirror if available", candidateUrl);
+        }
+
+        if (!downloadOk)
+        {
+            spdlog::error("All download candidates exhausted");
+            RestoreBackup();
+            if (!silent)
+                MessageBoxA(hwnd, "Failed to download the updater binary from all mirrors.",
+                            "Self-update failed", MB_ICONERROR | MB_OK);
+            return;
+        }
+
         spdlog::info("Download finished");
 
         // ----------------------------------------------------------------

--- a/dll/framework.h
+++ b/dll/framework.h
@@ -25,6 +25,7 @@
 
 #include <argh.h>
 
+#include <curl/curl.h>
 #include <curlpp/cURLpp.hpp>
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   models/DownloadLocationConfig.h
   models/InstanceConfig.hpp
   models/MergedConfig.hpp
+  models/NetworkConfig.hpp
   models/ProductDetection.hpp
   models/SharedConfig.hpp
   models/SignatureValidation.hpp
@@ -80,6 +81,7 @@ target_link_libraries(
   taskschd
   Version
   runtimeobject
+  winhttp
   wintrust
 )
 

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -5,9 +5,180 @@
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>
 
+#pragma comment(lib, "winhttp.lib")
+
+
+namespace
+{
+    // Convert a wide WinHTTP proxy string "host:port" into a libcurl proxy URL.
+    // WinHTTP may return a semicolon-separated list; we take the first entry.
+    std::string WinHttpProxyToUrl(const std::wstring& proxyList)
+    {
+        if (proxyList.empty()) return {};
+
+        // Take the first entry before any ';'
+        const auto sep = proxyList.find(L';');
+        std::wstring first = (sep != std::wstring::npos) ? proxyList.substr(0, sep) : proxyList;
+
+        // Trim whitespace
+        while (!first.empty() && iswspace(first.front())) first.erase(first.begin());
+        while (!first.empty() && iswspace(first.back()))  first.pop_back();
+        if (first.empty()) return {};
+
+        // Convert to narrow
+        const int len = WideCharToMultiByte(CP_UTF8, 0, first.c_str(), -1, nullptr, 0, nullptr, nullptr);
+        if (len <= 0) return {};
+        std::string narrow(len - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, first.c_str(), -1, narrow.data(), len, nullptr, nullptr);
+
+        // Prepend http:// if there's no scheme already
+        if (narrow.find("://") == std::string::npos)
+            narrow = "http://" + narrow;
+
+        return narrow;
+    }
+}
 
 namespace web
 {
+    std::optional<std::string> DetectSystemProxy(const std::string& targetUrl)
+    {
+        WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ieConfig{};
+        if (!WinHttpGetIEProxyConfigForCurrentUser(&ieConfig))
+        {
+            // API failure — cannot determine proxy; fall through to direct.
+            return std::nullopt;
+        }
+
+        // Guard: free the IE config strings on scope exit.
+        auto freeIeConfig = [&]
+        {
+            if (ieConfig.lpszProxy)           GlobalFree(ieConfig.lpszProxy);
+            if (ieConfig.lpszProxyBypass)     GlobalFree(ieConfig.lpszProxyBypass);
+            if (ieConfig.lpszAutoConfigUrl)   GlobalFree(ieConfig.lpszAutoConfigUrl);
+        };
+
+        // Case 1: Static proxy configured directly.
+        if (!ieConfig.fAutoDetect && ieConfig.lpszProxy && ieConfig.lpszAutoConfigUrl == nullptr)
+        {
+            std::string proxy = WinHttpProxyToUrl(ieConfig.lpszProxy);
+            freeIeConfig();
+            return proxy.empty() ? std::nullopt : std::optional<std::string>(proxy);
+        }
+
+        // Case 2: PAC script URL or WPAD auto-detect — must evaluate the PAC.
+        const bool hasPacUrl   = (ieConfig.lpszAutoConfigUrl != nullptr);
+        const bool autoDetect  = (ieConfig.fAutoDetect != FALSE);
+
+        if (!hasPacUrl && !autoDetect)
+        {
+            freeIeConfig();
+            return std::nullopt; // explicitly configured as direct
+        }
+
+        // Convert target URL to wide for WinHTTP APIs.
+        const int wlen = MultiByteToWideChar(CP_UTF8, 0, targetUrl.c_str(), -1, nullptr, 0);
+        std::wstring wideTarget(wlen > 0 ? wlen - 1 : 0, L'\0');
+        if (wlen > 0) MultiByteToWideChar(CP_UTF8, 0, targetUrl.c_str(), -1, wideTarget.data(), wlen);
+
+        HINTERNET hSession = WinHttpOpen(
+            L"Vicius/ProbeProxy",
+            WINHTTP_ACCESS_TYPE_NO_PROXY,
+            WINHTTP_NO_PROXY_NAME,
+            WINHTTP_NO_PROXY_BYPASS,
+            0);
+
+        if (!hSession)
+        {
+            freeIeConfig();
+            return std::nullopt;
+        }
+
+        WINHTTP_AUTOPROXY_OPTIONS autoProxyOpts{};
+        autoProxyOpts.dwFlags = 0;
+
+        if (hasPacUrl)
+        {
+            autoProxyOpts.dwFlags            |= WINHTTP_AUTOPROXY_CONFIG_URL;
+            autoProxyOpts.lpszAutoConfigUrl   = ieConfig.lpszAutoConfigUrl;
+        }
+        if (autoDetect)
+        {
+            autoProxyOpts.dwFlags            |= WINHTTP_AUTOPROXY_AUTO_DETECT;
+            autoProxyOpts.dwAutoDetectFlags   = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+        }
+        autoProxyOpts.fAutoLogonIfChallenged = TRUE;
+
+        WINHTTP_PROXY_INFO proxyInfo{};
+        const BOOL ok = WinHttpGetProxyForUrl(hSession, wideTarget.c_str(), &autoProxyOpts, &proxyInfo);
+
+        WinHttpCloseHandle(hSession);
+        freeIeConfig();
+
+        if (!ok) return std::nullopt;
+
+        std::optional<std::string> result;
+        if (proxyInfo.lpszProxy && proxyInfo.dwAccessType != WINHTTP_ACCESS_TYPE_NO_PROXY)
+        {
+            std::string proxy = WinHttpProxyToUrl(proxyInfo.lpszProxy);
+            if (!proxy.empty()) result = proxy;
+        }
+
+        if (proxyInfo.lpszProxy)       GlobalFree(proxyInfo.lpszProxy);
+        if (proxyInfo.lpszProxyBypass) GlobalFree(proxyInfo.lpszProxyBypass);
+
+        return result;
+    }
+
+    FailureKind ClassifyTransportError(const std::string& msg)
+    {
+        // All comparisons are case-insensitive so we lower-case once.
+        std::string lo;
+        lo.reserve(msg.size());
+        for (unsigned char c : msg)
+            lo.push_back(static_cast<char>(std::tolower(c)));
+
+        // DNS resolution failure (curl error 6: "Couldn't resolve host …")
+        if (lo.find("resolve host") != std::string::npos ||
+            lo.find("couldn't resolve") != std::string::npos ||
+            lo.find("could not resolve") != std::string::npos ||
+            lo.find("name resolution") != std::string::npos)
+        {
+            return FailureKind::DnsFailure;
+        }
+
+        // TLS / SSL failure (curl errors 35, 51, 58, 59, 60, 77, 80, 82, 83…)
+        if (lo.find("ssl") != std::string::npos ||
+            lo.find("tls") != std::string::npos ||
+            lo.find("certificate") != std::string::npos ||
+            lo.find("handshake") != std::string::npos ||
+            lo.find("peer cert") != std::string::npos)
+        {
+            return FailureKind::TlsError;
+        }
+
+        // Timeout / stall (curl errors 28, 29)
+        if (lo.find("timeout") != std::string::npos ||
+            lo.find("timed out") != std::string::npos ||
+            lo.find("operation too slow") != std::string::npos)
+        {
+            return FailureKind::Timeout;
+        }
+
+        // Connection refused / unreachable (curl errors 7, 9)
+        if (lo.find("connection refused") != std::string::npos ||
+            lo.find("couldn't connect") != std::string::npos ||
+            lo.find("could not connect") != std::string::npos ||
+            lo.find("failed to connect") != std::string::npos ||
+            lo.find("network unreachable") != std::string::npos ||
+            lo.find("no route to host") != std::string::npos)
+        {
+            return FailureKind::ConnectionRefused;
+        }
+
+        return FailureKind::Other;
+    }
+
     std::expected<HttpResult, std::string> HttpGet(const std::string& url, const HttpGetOptions& opts)
     {
         HttpResult result{};
@@ -69,6 +240,10 @@ namespace web
         // ----------------------------------------------------------------
         // curlpp request
         // ----------------------------------------------------------------
+
+        // CURLOPT_RESOLVE entries must outlive the perform() call.
+        curl_slist* resolveList = nullptr;
+
         try
         {
             curlpp::Easy req;
@@ -88,17 +263,47 @@ namespace web
             req.setOpt(curlpp::options::WriteFunction(writeCallback));
             req.setOpt(curlpp::options::HeaderFunction(headerCallback));
 
+            // Proxy — explicit value overrides; empty string means direct (no proxy).
+            if (opts.proxy.has_value())
+            {
+                req.setOpt(curlpp::options::Proxy(opts.proxy.value()));
+            }
+
+            // IP version preference
+            if (opts.ipResolve != CURL_IPRESOLVE_WHATEVER)
+            {
+                req.setOpt(curlpp::options::IpResolve(opts.ipResolve));
+            }
+
+            // DNS-over-HTTPS — requires libcurl >= 7.62; raw setopt since curlpp
+            // does not expose a typed wrapper for CURLOPT_DOH_URL.
+            if (!opts.dohUrl.empty())
+            {
+                curl_easy_setopt(req.getHandle(), CURLOPT_DOH_URL, opts.dohUrl.c_str());
+            }
+
+            // Static host→IP pins (CURLOPT_RESOLVE)
+            if (!opts.resolveHosts.empty())
+            {
+                for (const auto& entry : opts.resolveHosts)
+                    resolveList = curl_slist_append(resolveList, entry.c_str());
+                curl_easy_setopt(req.getHandle(), CURLOPT_RESOLVE, resolveList);
+            }
+
             req.perform();
         }
         catch (const curlpp::RuntimeError& e)
         {
+            if (resolveList) curl_slist_free_all(resolveList);
             return std::unexpected(std::string(e.what()));
         }
         catch (const curlpp::LogicError& e)
         {
+            if (resolveList) curl_slist_free_all(resolveList);
             return std::unexpected(std::string(e.what()));
         }
 
+        if (resolveList) curl_slist_free_all(resolveList);
         return result;
     }
 }

--- a/src/Http.h
+++ b/src/Http.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <list>
 #include <unordered_map>
+#include <optional>
 #include <expected>
 
 
@@ -25,9 +26,6 @@ namespace web
 
     /**
      * \brief Options for HttpGet.
-     *
-     * A proxy field is intentionally left as a commented stub so that
-     * adding proxy support (issue #146) requires a change in one place only.
      */
     struct HttpGetOptions
     {
@@ -36,8 +34,72 @@ namespace web
         long timeoutSecs{0};
         long connectTimeoutSecs{60};
         long maxRedirects{5};
-        // future: std::optional<std::string> proxy;
+
+        /**
+         * Proxy URL, e.g. "http://user:pass@proxy.corp:8080".
+         * When empty the request goes direct (no proxy).
+         */
+        std::optional<std::string> proxy;
+
+        /**
+         * DNS-over-HTTPS resolver URL, e.g. "https://cloudflare-dns.com/dns-query".
+         * When non-empty, curl uses DoH for name resolution of this request.
+         * Requires libcurl >= 7.62.
+         */
+        std::string dohUrl;
+
+        /**
+         * Static host→IP pin entries fed to CURLOPT_RESOLVE.
+         * Each entry must be in curl's format: "host:port:address[,address2]"
+         * e.g. "vicius.api.nefarius.systems:443:104.21.0.1"
+         */
+        std::list<std::string> resolveHosts;
+
+        /**
+         * IP version preference for DNS resolution (CURLOPT_IPRESOLVE).
+         * Accepted values: CURL_IPRESOLVE_WHATEVER (0), CURL_IPRESOLVE_V4 (1),
+         * CURL_IPRESOLVE_V6 (2).
+         */
+        long ipResolve{CURL_IPRESOLVE_WHATEVER};
     };
+
+    /**
+     * \brief Coarse failure category for a transport error string returned by HttpGet.
+     *
+     * Used by callers to apply category-specific recovery (DoH retry on DnsFailure,
+     * fast failover on ConnectionRefused/TlsError, timeout escalation on Timeout).
+     */
+    enum class FailureKind
+    {
+        None,
+        DnsFailure,        ///< Could not resolve the host name
+        ConnectionRefused, ///< Host reachable but refused the connection
+        TlsError,          ///< TLS/SSL handshake or certificate failure
+        Timeout,           ///< Connection or transfer stall timeout
+        Other,             ///< Any other transport error
+    };
+
+    /**
+     * \brief Maps a curlpp transport error string to a FailureKind.
+     *
+     * The error strings produced by libcurl are stable English prose sourced from
+     * curl_easy_strerror(). We match on stable substrings that have not changed
+     * across the libcurl versions in use.
+     */
+    FailureKind ClassifyTransportError(const std::string& curlMessage);
+
+    /**
+     * \brief Detects the Windows system/WinINET proxy for the given target URL.
+     *
+     * Reads the per-user IE/WinINET proxy settings and, when a PAC script or
+     * WPAD auto-detect is configured, evaluates the PAC for the supplied URL.
+     *
+     * \param targetUrl The URL that will be fetched (used for PAC evaluation).
+     * \return A proxy URL string (e.g. "http://proxy.corp:8080") when a proxy
+     *         is configured for the target; std::nullopt when the connection
+     *         should be direct (no proxy).
+     */
+    std::optional<std::string> DetectSystemProxy(const std::string& targetUrl);
 
     /**
      * \brief Performs an in-memory HTTP GET using curlpp.
@@ -47,9 +109,6 @@ namespace web
      * handshake failure, stall timeout, etc.). HTTP error status codes (4xx,
      * 5xx) are NOT transport failures — they are returned inside HttpResult so
      * the caller can apply its own retry / fallback logic.
-     *
-     * Timeout failures include the word "timeout" in the error string, which
-     * callers can test to apply exponential back-off.
      */
     std::expected<HttpResult, std::string> HttpGet(const std::string& url, const HttpGetOptions& opts);
 }

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "Common.h"
+#include "Http.h"
 #include "Util.h"
 #include "InstanceConfig.hpp"
 
@@ -103,6 +104,24 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
         spdlog::warn("No checksum available for self-updater binary; verification will be Authenticode-only");
     }
 
+    // Build mirror URL args (passed as repeated --mirror-url).
+    std::string mirrorArgs;
+    if (inst.latestMirrorUrls.has_value())
+    {
+        for (const auto& m : inst.latestMirrorUrls.value())
+            mirrorArgs += std::format(" --mirror-url \"{}\"", m);
+    }
+
+    // Build network args (proxy, DoH) from the sidecar NetworkConfig.
+    std::string networkArgs;
+    {
+        const web::HttpGetOptions netOpts = BuildBaseHttpOptions(latestUrl);
+        if (netOpts.proxy.has_value() && !netOpts.proxy->empty())
+            networkArgs += std::format(" --proxy \"{}\"", *netOpts.proxy);
+        if (!netOpts.dohUrl.empty())
+            networkArgs += std::format(" --doh-url \"{}\"", netOpts.dohUrl);
+    }
+
     // if we can write to our directory, spawn under current user
     if (HasWritePermissions())
     {
@@ -121,7 +140,9 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
                    << " --pid " << GetCurrentProcessId()
                    << " --path \"" << appPath.string() << "\""
                    << " --url \"" << latestUrl << "\""
-                   << checksumArgs;
+                   << checksumArgs
+                   << mirrorArgs
+                   << networkArgs;
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 
@@ -161,7 +182,9 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
                    << " --pid " << GetCurrentProcessId()
                    << " --path \"" << appPath.string() << "\""
                    << " --url \"" << latestUrl << "\""
-                   << checksumArgs;
+                   << checksumArgs
+                   << mirrorArgs
+                   << networkArgs;
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -4,6 +4,51 @@
 #include "Util.h"
 #include "InstanceConfig.hpp"
 
+namespace
+{
+    /**
+     * \brief Quotes and escapes a single argument value for safe inclusion in a
+     * CreateProcess / ShellExecuteEx command string that will be parsed by
+     * CommandLineToArgvW.
+     *
+     * Algorithm: wrap in double-quotes, doubling any backslashes that immediately
+     * precede a double-quote or end the string, and escaping every embedded
+     * double-quote as \".
+     * See https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw
+     */
+    std::string QuoteArg(const std::string& arg)
+    {
+        std::string out;
+        out.reserve(arg.size() + 4);
+        out += '"';
+        size_t backslashes = 0;
+        for (const char c : arg)
+        {
+            if (c == '\\')
+            {
+                ++backslashes;
+            }
+            else if (c == '"')
+            {
+                // Double any preceding backslashes, then escape the quote.
+                out.append(backslashes * 2, '\\');
+                out += "\\\"";
+                backslashes = 0;
+            }
+            else
+            {
+                out.append(backslashes, '\\');
+                out += c;
+                backslashes = 0;
+            }
+        }
+        // Double trailing backslashes (they precede the closing quote).
+        out.append(backslashes * 2, '\\');
+        out += '"';
+        return out;
+    }
+}
+
 
 std::expected<void, std::string> models::InstanceConfig::ExtractSelfUpdater() const
 {
@@ -109,17 +154,22 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
     if (inst.latestMirrorUrls.has_value())
     {
         for (const auto& m : inst.latestMirrorUrls.value())
-            mirrorArgs += std::format(" --mirror-url \"{}\"", m);
+            mirrorArgs += " --mirror-url " + QuoteArg(m);
     }
 
     // Build network args (proxy, DoH) from the sidecar NetworkConfig.
     std::string networkArgs;
     {
         const web::HttpGetOptions netOpts = BuildBaseHttpOptions(latestUrl);
-        if (netOpts.proxy.has_value() && !netOpts.proxy->empty())
-            networkArgs += std::format(" --proxy \"{}\"", *netOpts.proxy);
+        if (netOpts.proxy.has_value())
+        {
+            if (!netOpts.proxy->empty())
+                networkArgs += " --proxy " + QuoteArg(*netOpts.proxy);
+            else
+                networkArgs += " --no-proxy"; // ProxyMode::None — force direct in the DLL
+        }
         if (!netOpts.dohUrl.empty())
-            networkArgs += std::format(" --doh-url \"{}\"", netOpts.dohUrl);
+            networkArgs += " --doh-url " + QuoteArg(netOpts.dohUrl);
     }
 
     // if we can write to our directory, spawn under current user
@@ -138,8 +188,8 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
                    << " --silent"
                    << " --log-level " << magic_enum::enum_name(spdlog::get_level())
                    << " --pid " << GetCurrentProcessId()
-                   << " --path \"" << appPath.string() << "\""
-                   << " --url \"" << latestUrl << "\""
+                   << " --path " << QuoteArg(appPath.string())
+                   << " --url "  << QuoteArg(latestUrl)
                    << checksumArgs
                    << mirrorArgs
                    << networkArgs;
@@ -180,8 +230,8 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
                    << " --silent"
                    << " --log-level " << magic_enum::enum_name(spdlog::get_level())
                    << " --pid " << GetCurrentProcessId()
-                   << " --path \"" << appPath.string() << "\""
-                   << " --url \"" << latestUrl << "\""
+                   << " --path " << QuoteArg(appPath.string())
+                   << " --url "  << QuoteArg(latestUrl)
                    << checksumArgs
                    << mirrorArgs
                    << networkArgs;

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -939,15 +939,16 @@ namespace
                     continue;
                 }
 
-                // Connection refused / TLS errors rarely self-heal — exhaust at most 2
-                // retries and then fail over to the next mirror quickly.
+                // Connection refused / TLS errors rarely self-heal — cap the remaining
+                // retry budget to at most 2 so we fail over to the next mirror quickly.
                 const bool isFastFailover =
                     (kind == web::FailureKind::ConnectionRefused ||
                      kind == web::FailureKind::TlsError);
 
-                const int effectiveRetries = isFastFailover ? std::min(retryCount, 2) : retryCount;
+                if (isFastFailover && retryCount > 2)
+                    retryCount = 2;
 
-                if (effectiveRetries > 0 && --retryCount > 0)
+                if (--retryCount > 0)
                 {
                     spdlog::debug("Web request failed ({}), retrying {} more time(s)", transportError, retryCount);
 

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -44,6 +44,68 @@ std::list<std::string> models::InstanceConfig::BuildCommonHeaders() const
     return lines;
 }
 
+web::HttpGetOptions models::InstanceConfig::BuildBaseHttpOptions(const std::string& targetUrl) const
+{
+    web::HttpGetOptions opts;
+
+    // --- Proxy ---
+    const ProxyMode mode = network.has_value() ? network->proxyMode : ProxyMode::System;
+
+    switch (mode)
+    {
+        case ProxyMode::None:
+            // Force direct; an explicit empty string tells libcurl to disable proxy,
+            // including any env-var proxy that might otherwise be picked up.
+            opts.proxy = std::string{};
+            break;
+
+        case ProxyMode::Manual:
+            if (network.has_value() && !network->proxyUrl.empty())
+                opts.proxy = network->proxyUrl;
+            break;
+
+        case ProxyMode::System:
+        default:
+        {
+            auto detected = web::DetectSystemProxy(targetUrl);
+            if (detected.has_value())
+            {
+                spdlog::debug("System proxy detected for {}: {}", targetUrl, *detected);
+                opts.proxy = std::move(detected);
+            }
+            // else: no proxy configured in OS — leave opts.proxy empty (direct)
+            break;
+        }
+    }
+
+    // --- DoH ---
+    if (network.has_value() && !network->dohUrl.empty())
+        opts.dohUrl = network->dohUrl;
+
+    // --- IP family ---
+    if (network.has_value())
+    {
+        switch (network->ipFamily)
+        {
+            case IpFamily::V4: opts.ipResolve = CURL_IPRESOLVE_V4; break;
+            case IpFamily::V6: opts.ipResolve = CURL_IPRESOLVE_V6; break;
+            default:           opts.ipResolve = CURL_IPRESOLVE_WHATEVER; break;
+        }
+    }
+
+    // --- Pinned hosts ---
+    if (network.has_value())
+    {
+        for (const auto& pin : network->pinnedHosts)
+        {
+            if (!pin.host.empty() && !pin.address.empty())
+                opts.resolveHosts.push_back(pin.ToCurlResolveEntry());
+        }
+    }
+
+    return opts;
+}
+
 std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_progress_callback progressFn, const int releaseIndex)
 {
     UNREFERENCED_PARAMETER(releaseIndex);
@@ -104,6 +166,15 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
 
     auto& release = GetSelectedRelease();
 
+    // Build the ordered list of download URLs: primary first, then mirrors.
+    std::vector<std::string> candidateDownloadUrls;
+    candidateDownloadUrls.push_back(release.downloadUrl);
+    if (release.mirrorUrls.has_value())
+    {
+        for (const auto& m : release.mirrorUrls.value())
+            candidateDownloadUrls.push_back(m);
+    }
+
     // Reuse existing temp file if present (allows resuming across user retries)
     if (release.localTempFilePath.empty())
     {
@@ -132,6 +203,37 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
     constexpr long kMaxTimeoutSecs = MAX_TIMEOUT_SECS_TOTAL;
     std::string lastFailureDetails{};
     std::optional<std::filesystem::path> cachedAttachmentName{};
+
+    // Mirror-failover outer loop — iterates when all retries on a URL are exhausted.
+    for (size_t urlIdx = 0; urlIdx < candidateDownloadUrls.size(); ++urlIdx)
+    {
+    const std::string& currentDownloadUrl = candidateDownloadUrls[urlIdx];
+
+    if (urlIdx > 0)
+    {
+        spdlog::warn("Switching to mirror URL ({}/{}): {}", urlIdx + 1, candidateDownloadUrls.size(), currentDownloadUrl);
+
+        // Reset retry state for the new mirror.
+        retryCount = MAX_RETRY_COUNT;
+        currentTimeoutSecs = MAX_TIMEOUT_SECS;
+        lastFailureDetails.clear();
+        cachedAttachmentName.reset();
+
+        // Discard the partial temp file — mirror may serve different content/layout.
+        if (!release.localTempFilePath.empty())
+        {
+            try
+            {
+                if (outStream.is_open()) outStream.close();
+                outStream.open(release.localTempFilePath.string(), std::ios::binary | std::ios::trunc);
+                outStream.close();
+            }
+            catch (...) {}
+        }
+    }
+
+    // Resolve network options for this URL (proxy, DoH, pins, IP family).
+    const web::HttpGetOptions baseNetOpts = BuildBaseHttpOptions(currentDownloadUrl);
 
     auto tryGetHeader = [](const auto& headers, const std::string& key) -> std::string
     {
@@ -253,7 +355,8 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
             return std::unexpected(std::format("Failed to open temporary file '{}': {}", release.localTempFilePath.string(), e.what()));
         }
 
-        spdlog::debug("Starting release download from {} (timeout {}s)", release.downloadUrl, currentTimeoutSecs);
+        spdlog::debug("Starting release download from {} (timeout {}s, mirror {}/{})",
+                      currentDownloadUrl, currentTimeoutSecs, urlIdx + 1, candidateDownloadUrls.size());
         if (wantsResume)
         {
             const auto rangeHeader = std::format("bytes={}-", localSize);
@@ -361,8 +464,11 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         // Build common vendor + additional headers via the shared helper
         std::list<std::string> headerLines = BuildCommonHeaders();
 
+        // CURLOPT_RESOLVE list must outlive perform().
+        curl_slist* downloadResolveList = nullptr;
+
         curlpp::Easy req;
-        req.setOpt(curlpp::options::Url(release.downloadUrl));
+        req.setOpt(curlpp::options::Url(currentDownloadUrl));
         req.setOpt(curlpp::options::UserAgent(ua));
         req.setOpt(curlpp::options::FollowLocation(true));
         req.setOpt(curlpp::options::MaxRedirs(MAX_REDIRECTS));
@@ -372,6 +478,20 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         req.setOpt(curlpp::options::ConnectTimeout(60));
         req.setOpt(curlpp::options::LowSpeedLimit(1));
         req.setOpt(curlpp::options::LowSpeedTime(currentTimeoutSecs));
+
+        // Network resilience options from sidecar NetworkConfig
+        if (baseNetOpts.proxy.has_value())
+            req.setOpt(curlpp::options::Proxy(baseNetOpts.proxy.value()));
+        if (baseNetOpts.ipResolve != CURL_IPRESOLVE_WHATEVER)
+            req.setOpt(curlpp::options::IpResolve(baseNetOpts.ipResolve));
+        if (!baseNetOpts.dohUrl.empty())
+            curl_easy_setopt(req.getHandle(), CURLOPT_DOH_URL, baseNetOpts.dohUrl.c_str());
+        if (!baseNetOpts.resolveHosts.empty())
+        {
+            for (const auto& entry : baseNetOpts.resolveHosts)
+                downloadResolveList = curl_slist_append(downloadResolveList, entry.c_str());
+            curl_easy_setopt(req.getHandle(), CURLOPT_RESOLVE, downloadResolveList);
+        }
 
         // Streaming write + header collection
         req.setOpt(curlpp::options::WriteFunction(writeCallback));
@@ -410,11 +530,15 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         {
             req.perform();
 
+            if (downloadResolveList) { curl_slist_free_all(downloadResolveList); downloadResolveList = nullptr; }
+
             // If we didn't parse an HTTP status line, treat as OK (best-effort).
             code = headerCollector.lastHttpCode != 0 ? static_cast<int>(headerCollector.lastHttpCode) : httplib::OK_200;
         }
         catch (const curlpp::RuntimeError& e)
         {
+            if (downloadResolveList) { curl_slist_free_all(downloadResolveList); downloadResolveList = nullptr; }
+
             if (abortDownloadRequested.load(std::memory_order_relaxed))
             {
                 spdlog::info("Download aborted");
@@ -472,6 +596,7 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         }
         catch (const curlpp::LogicError& e)
         {
+            if (downloadResolveList) { curl_slist_free_all(downloadResolveList); downloadResolveList = nullptr; }
             spdlog::error("cURLpp logic error: {}", e.what());
             lastFailureDetails = e.what();
             code = static_cast<int>(CURLE_FAILED_INIT);
@@ -672,11 +797,22 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         const std::string finalErrorMsg = !lastFailureDetails.empty()
                                               ? lastFailureDetails
                                               : (errorMessage.empty() ? httplib::status_message(code) : std::string(errorMessage));
-        spdlog::error("GET request failed with code {}, message {}", code, finalErrorMsg);
+        spdlog::error("Download failed from {} with code {}, message {}", currentDownloadUrl, code, finalErrorMsg);
+
+        if ((urlIdx + 1) < candidateDownloadUrls.size())
+        {
+            spdlog::warn("Exhausted retries for {}, will try next mirror", currentDownloadUrl);
+            break; // exits the while(true), outer for loop advances to next mirror
+        }
 
         // Keep partial file to allow resuming on next user retry (only remove on 404 above)
         return std::unexpected(finalErrorMsg);
-    }
+    } // while(true) retry loop
+
+    } // for (urlIdx) mirror loop
+
+    // All mirrors exhausted — return the last failure
+    return std::unexpected(!lastFailureDetails.empty() ? lastFailureDetails : "All download mirrors failed");
 }
 
 // ============================================================================
@@ -753,35 +889,76 @@ namespace
         int retryCount = 5;
         currentTimeoutSecs = MAX_TIMEOUT_SECS;
 
+        // Whether we've already tried a DNS-fallback (DoH/pinned-IP) on this candidate URL.
+        bool dnsRecoveryAttempted = false;
+
+        // Base options (proxy, DoH, pinned hosts, IP family) resolved from NetworkConfig.
+        web::HttpGetOptions baseOpts = BuildBaseHttpOptions(requestUrl);
+
         while (true)
         {
-            auto getResult = web::HttpGet(requestUrl, {
-                .userAgent          = ua,
-                .headers            = buildManifestHeaders(),
-                .timeoutSecs        = currentTimeoutSecs,
-                .connectTimeoutSecs = 60,
-                .maxRedirects       = MAX_REDIRECTS,
-            });
+            web::HttpGetOptions reqOpts  = baseOpts;
+            reqOpts.userAgent            = ua;
+            reqOpts.headers              = buildManifestHeaders();
+            reqOpts.timeoutSecs          = currentTimeoutSecs;
+            reqOpts.connectTimeoutSecs   = 60;
+            reqOpts.maxRedirects         = MAX_REDIRECTS;
+
+            auto getResult = web::HttpGet(requestUrl, reqOpts);
 
             // Transport failure (connection error, TLS failure, stall timeout, …)
             if (!getResult)
             {
                 const std::string& transportError = getResult.error();
-                const bool isTimeout =
-                    transportError.find("timeout") != std::string::npos ||
-                    transportError.find("Timeout") != std::string::npos ||
-                    transportError.find("timed out") != std::string::npos ||
-                    transportError.find("Timed out") != std::string::npos;
+                const web::FailureKind kind = web::ClassifyTransportError(transportError);
 
-                if (--retryCount > 0)
+                spdlog::debug("Transport error (kind={}): {}",
+                              static_cast<int>(kind), transportError);
+
+                // DNS failure: if we have DoH or a matching pinned-host entry and haven't
+                // tried DNS recovery on this URL yet, do one immediate retry with DoH
+                // explicitly forced (even when it was already set, re-applying is harmless).
+                const bool hasDnsRecovery =
+                    (network.has_value() && (
+                        !network->dohUrl.empty() ||
+                        std::any_of(network->pinnedHosts.begin(), network->pinnedHosts.end(),
+                            [&](const PinnedHost& p)
+                            {
+                                return requestUrl.find(p.host) != std::string::npos;
+                            })));
+
+                if (kind == web::FailureKind::DnsFailure && hasDnsRecovery && !dnsRecoveryAttempted)
+                {
+                    dnsRecoveryAttempted = true;
+                    spdlog::warn("DNS resolution failed for {}; retrying with DoH/pinned-IP recovery", requestUrl);
+                    // Force DoH on the next iteration via baseOpts (already set if dohUrl
+                    // was configured; if not, set it to Cloudflare as a last resort so the
+                    // recovery attempt actually bypasses the broken resolver).
+                    if (baseOpts.dohUrl.empty())
+                        baseOpts.dohUrl = "https://cloudflare-dns.com/dns-query";
+                    continue;
+                }
+
+                // Connection refused / TLS errors rarely self-heal — exhaust at most 2
+                // retries and then fail over to the next mirror quickly.
+                const bool isFastFailover =
+                    (kind == web::FailureKind::ConnectionRefused ||
+                     kind == web::FailureKind::TlsError);
+
+                const int effectiveRetries = isFastFailover ? std::min(retryCount, 2) : retryCount;
+
+                if (effectiveRetries > 0 && --retryCount > 0)
                 {
                     spdlog::debug("Web request failed ({}), retrying {} more time(s)", transportError, retryCount);
 
-                    std::mt19937_64 eng{std::random_device{}()};
-                    std::uniform_int_distribution<> dist{1000, 5000};
-                    std::this_thread::sleep_for(std::chrono::milliseconds{dist(eng)});
+                    if (!isFastFailover)
+                    {
+                        std::mt19937_64 eng{std::random_device{}()};
+                        std::uniform_int_distribution<> dist{1000, 5000};
+                        std::this_thread::sleep_for(std::chrono::milliseconds{dist(eng)});
+                    }
 
-                    if (isTimeout)
+                    if (kind == web::FailureKind::Timeout)
                     {
                         long nxt = std::lround(currentTimeoutSecs * 1.5);
                         currentTimeoutSecs = std::min(nxt, 900L);
@@ -795,7 +972,7 @@ namespace
 
                 if ((i + 1) < candidateUrls.size())
                 {
-                    spdlog::warn("Primary URL not accessible ({}), attempting fallback", transportError);
+                    spdlog::warn("URL {} not accessible ({}), attempting fallback", requestUrl, transportError);
                     break; // try next candidate URL
                 }
 
@@ -843,13 +1020,14 @@ namespace
                     const std::string minisigUrl = requestUrl + ".minisig";
                     spdlog::debug("Fetching manifest signature from {}", minisigUrl);
 
-                    auto sigGetResult = web::HttpGet(minisigUrl, {
-                        .userAgent          = ua,
-                        .headers            = BuildCommonHeaders(),
-                        .timeoutSecs        = MAX_TIMEOUT_SECS,
-                        .connectTimeoutSecs = 60,
-                        .maxRedirects       = MAX_REDIRECTS,
-                    });
+                    web::HttpGetOptions sigOpts  = baseOpts;
+                    sigOpts.userAgent            = ua;
+                    sigOpts.headers              = BuildCommonHeaders();
+                    sigOpts.timeoutSecs          = MAX_TIMEOUT_SECS;
+                    sigOpts.connectTimeoutSecs   = 60;
+                    sigOpts.maxRedirects         = MAX_REDIRECTS;
+
+                    auto sigGetResult = web::HttpGet(minisigUrl, sigOpts);
 
                     const bool sigOk = sigGetResult.has_value()
                         && sigGetResult->httpCode == httplib::OK_200
@@ -925,6 +1103,21 @@ namespace
                             std::format("Release '{}' uses a non-HTTPS downloadUrl which is not allowed for security reasons.",
                                         release.name));
                     }
+
+                    if (release.mirrorUrls.has_value())
+                    {
+                        for (const auto& mirror : release.mirrorUrls.value())
+                        {
+                            if (!IsAllowedDownloadUrl(mirror))
+                            {
+                                spdlog::error("Release '{}' has a disallowed mirrorUrl scheme: {}",
+                                              release.name, mirror);
+                                return std::unexpected(
+                                    std::format("Release '{}' has a mirrorUrl with a non-HTTPS scheme which is not allowed.",
+                                                release.name));
+                            }
+                        }
+                    }
                 }
 
                 if (remote.instance.has_value())
@@ -935,6 +1128,19 @@ namespace
                         spdlog::error("instance.latestUrl has a disallowed scheme: {}", inst.latestUrl.value());
                         return std::unexpected(
                             "The self-updater URL (instance.latestUrl) uses a non-HTTPS scheme which is not allowed.");
+                    }
+
+                    if (inst.latestMirrorUrls.has_value())
+                    {
+                        for (const auto& mirror : inst.latestMirrorUrls.value())
+                        {
+                            if (!IsAllowedDownloadUrl(mirror))
+                            {
+                                spdlog::error("instance.latestMirrorUrls contains a disallowed scheme: {}", mirror);
+                                return std::unexpected(
+                                    "An instance.latestMirrorUrl uses a non-HTTPS scheme which is not allowed.");
+                            }
+                        }
                     }
                 }
 

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -409,6 +409,23 @@ models::InstanceConfig::InstanceConfig(HINSTANCE hInstance, argh::parser& cmdl, 
                 channel = data.value("/instance/channel"_json_pointer, channel);
             }
 
+            // Network resilience settings
+            if (data.contains("/instance/network"_json_pointer))
+            {
+                try
+                {
+                    network = data.at("/instance/network"_json_pointer).get<NetworkConfig>();
+                    spdlog::info("Network config loaded: proxyMode={}, dohUrl={}, pinnedHosts={}",
+                                 magic_enum::enum_name(network->proxyMode),
+                                 network->dohUrl.empty() ? "(none)" : network->dohUrl,
+                                 network->pinnedHosts.size());
+                }
+                catch (const std::exception& e)
+                {
+                    spdlog::error("Failed to parse instance.network: {}", e.what());
+                }
+            }
+
             // populate shared config first either from JSON file or with built-in defaults
             if (data.contains("shared"))
             {

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -4,10 +4,12 @@
 #include <list>
 #include <string>
 
+#include "NetworkConfig.hpp"
 #include "UpdateResponse.hpp"
 #include "MergedConfig.hpp"
 #include "NAuthenticode.h"
 #include "../Util.h"
+#include "../Http.h"
 
 using json = nlohmann::json;
 
@@ -121,6 +123,19 @@ namespace models
 
         [[nodiscard]] std::list<std::string> BuildCommonHeaders() const;
 
+        /**
+         * \brief Builds an HttpGetOptions struct pre-populated from the NetworkConfig.
+         *
+         * Proxy is resolved according to proxyMode:
+         *   System  → DetectSystemProxy() for targetUrl
+         *   Manual  → network.proxyUrl
+         *   None    → explicit empty proxy (disables even env-var proxies)
+         * DoH, pinned hosts, and IP family are forwarded unchanged.
+         *
+         * \param targetUrl URL that will be fetched (used for PAC/WPAD evaluation).
+         */
+        [[nodiscard]] web::HttpGetOptions BuildBaseHttpOptions(const std::string& targetUrl) const;
+
         std::expected<SetupResult, std::string> ExecuteSetup(const std::stop_token&);
 
     public:
@@ -135,6 +150,13 @@ namespace models
         Authority authority;
         std::string channel;
         std::map<std::string, std::string> additionalHeaders;
+
+        /**
+         * \brief Optional network resilience settings loaded from the sidecar JSON
+         * under \c instance.network.  When absent, sensible defaults apply (system
+         * proxy auto-detect, direct DNS, no pinned hosts).
+         */
+        std::optional<NetworkConfig> network;
 
         InstanceConfig() : authority(Authority::Remote) { }
 
@@ -581,5 +603,5 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(InstanceConfig, serverUrlTemplate, fallbackServerUrlTemplates, filenameRegex,
-                                                    authority)
+                                                    authority, network)
 }

--- a/src/models/NetworkConfig.hpp
+++ b/src/models/NetworkConfig.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "../ADL.hpp"
+
+namespace models
+{
+    /**
+     * \brief How the updater should obtain an HTTP proxy.
+     */
+    enum class ProxyMode
+    {
+        /**
+         * Auto-detect from the Windows/WinINET system proxy settings
+         * (static proxy, PAC URL, or WPAD). This is the default.
+         */
+        System,
+        /** Always connect directly — no proxy, even if one is configured in the OS. */
+        None,
+        /** Use the URL specified in NetworkConfig::proxyUrl. */
+        Manual,
+        Invalid = -1,
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(ProxyMode, {
+        {ProxyMode::Invalid, nullptr},
+        {ProxyMode::System,  magic_enum::enum_name(ProxyMode::System)},
+        {ProxyMode::None,    magic_enum::enum_name(ProxyMode::None)},
+        {ProxyMode::Manual,  magic_enum::enum_name(ProxyMode::Manual)},
+    })
+
+    /**
+     * \brief Which IP address family libcurl should use for name resolution.
+     */
+    enum class IpFamily
+    {
+        /** Let libcurl choose (CURL_IPRESOLVE_WHATEVER). Default. */
+        Any,
+        /** Force IPv4 name resolution (CURL_IPRESOLVE_V4). */
+        V4,
+        /** Force IPv6 name resolution (CURL_IPRESOLVE_V6). */
+        V6,
+        Invalid = -1,
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(IpFamily, {
+        {IpFamily::Invalid, nullptr},
+        {IpFamily::Any,     magic_enum::enum_name(IpFamily::Any)},
+        {IpFamily::V4,      magic_enum::enum_name(IpFamily::V4)},
+        {IpFamily::V6,      magic_enum::enum_name(IpFamily::V6)},
+    })
+
+    /**
+     * \brief A static host→IP pin entry fed to libcurl via CURLOPT_RESOLVE.
+     *
+     * Forces the named host to resolve to the supplied IP address, bypassing
+     * normal DNS entirely for that host. Useful when DNS is poisoned or blocked.
+     */
+    struct PinnedHost
+    {
+        /** Hostname to pin, e.g. "vicius.api.nefarius.systems". */
+        std::string host;
+        /** Port number, e.g. 443. */
+        int port{443};
+        /** IP address to use, e.g. "104.21.0.1". May be IPv4 or IPv6. */
+        std::string address;
+
+        /**
+         * \brief Renders the entry in the format expected by CURLOPT_RESOLVE:
+         * "host:port:address"
+         */
+        [[nodiscard]] std::string ToCurlResolveEntry() const
+        {
+            return std::format("{}:{}:{}", host, port, address);
+        }
+    };
+
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PinnedHost, host, port, address)
+
+    /**
+     * \brief Per-deployment network resilience configuration, read from the
+     * sidecar JSON under \c instance.network.
+     *
+     * All fields are optional; sensible defaults are applied when absent.
+     */
+    struct NetworkConfig
+    {
+        /**
+         * How to obtain the proxy to use.
+         * Default: System (auto-detect from Windows/WinINET settings).
+         */
+        ProxyMode proxyMode{ProxyMode::System};
+
+        /**
+         * Explicit proxy URL used when proxyMode == Manual.
+         * Format: "http[s]://[user:pass@]host:port"
+         * e.g. "http://proxy.corp.example.com:8080"
+         */
+        std::string proxyUrl;
+
+        /**
+         * DNS-over-HTTPS resolver URL.
+         * When non-empty, libcurl uses DoH for all name resolutions in this
+         * session, bypassing the system resolver (useful against DNS censorship).
+         * Example: "https://cloudflare-dns.com/dns-query"
+         * Requires libcurl >= 7.62.
+         */
+        std::string dohUrl;
+
+        /**
+         * IP address family preference for DNS resolution.
+         * Default: Any (libcurl chooses). Set to V4 or V6 to force a specific
+         * family (e.g. V4 for environments where IPv6 is unreliable).
+         */
+        IpFamily ipFamily{IpFamily::Any};
+
+        /**
+         * Static host→IP pin entries.
+         * For each entry, libcurl bypasses DNS for that host and connects
+         * directly to the pinned IP.  Useful when DNS is blocked/poisoned but
+         * the IP is reachable.  The SNI hostname in TLS is still taken from the
+         * URL, so the TLS certificate must match the hostname.
+         */
+        std::vector<PinnedHost> pinnedHosts;
+    };
+
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+        NetworkConfig, proxyMode, proxyUrl, dohUrl, ipFamily, pinnedHosts)
+}

--- a/src/models/UpdateConfig.hpp
+++ b/src/models/UpdateConfig.hpp
@@ -20,6 +20,11 @@ namespace models
         /** URL of the latest updater binary */
         std::optional<std::string> latestUrl;
         /**
+         * \brief Optional mirror/fallback URLs for the self-updater binary.
+         * Tried in order when \c latestUrl is unreachable.  All URLs must use HTTPS.
+         */
+        std::optional<std::vector<std::string>> latestMirrorUrls;
+        /**
          * \brief Optional checksum of the self-updater binary at latestUrl.
          * Passed to the self-updater DLL so it can verify the download before swapping.
          */
@@ -68,5 +73,5 @@ namespace models
     };
 
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestChecksum, emergencyUrl, exitCode, helpUrl, errorFallbackUrl, runAsAdmin)
+      UpdateConfig, updatesDisabled, latestVersion, latestUrl, latestMirrorUrls, latestChecksum, emergencyUrl, exitCode, helpUrl, errorFallbackUrl, runAsAdmin)
 }

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -68,6 +68,12 @@ namespace models
         std::string publishedAt;
         /** URL of the new setup/release download */
         std::string downloadUrl;
+        /**
+         * \brief Optional list of mirror/alternative download URLs tried in order
+         * when \c downloadUrl is unreachable.  All URLs must use HTTPS.
+         * Useful when the primary CDN host is blocked by a firewall or censorship.
+         */
+        std::optional<std::vector<std::string>> mirrorUrls;
         /** Size of the remote file in bytes */
         std::optional<size_t> downloadSize;
         /** The launch arguments (CLI arguments) if any */
@@ -125,6 +131,7 @@ namespace models
                                                     summary,
                                                     publishedAt,
                                                     downloadUrl,
+                                                    mirrorUrls,
                                                     downloadSize,
                                                     launchArguments,
                                                     exitCode,

--- a/src/nefarius_HidHide_Updater.json
+++ b/src/nefarius_HidHide_Updater.json
@@ -4,7 +4,19 @@
 		"fallbackServerUrlTemplates": [
 			"https://example-mirror.invalid/api/{}/updates.json"
 		],
-		"authority": "Remote"
+		"authority": "Remote",
+
+		"network": {
+			"proxyMode": "System",
+
+			"proxyUrl": "",
+
+			"dohUrl": "",
+
+			"ipFamily": "Any",
+
+			"pinnedHosts": []
+		}
 	},
 	"shared":{
 		"productName": "HidHide"

--- a/src/vīcĭus.vcxproj.user
+++ b/src/vīcĭus.vcxproj.user
@@ -13,6 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerCommandArguments>--server-url http://localhost:5200/api/demo/Showcase/updates.json --log-level debug --log-to-file "$(TargetDir)debug.log"</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArgumentsHistory>--server-url http://localhost:5200/api/demo/Showcase/updates.json --log-level debug --log-to-file "D:\FOSS\vicius\x64\Debug\debug.log"|</LocalDebuggerCommandArgumentsHistory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-instance network configuration for update downloads, including proxy control, DNS-over-HTTPS, IP family selection, and optional hostname-to-IP pinning.
  * Added ordered fallback mirror URLs for both the self-updater and release downloads when the primary URL is unreachable.
* **Bug Fixes**
  * Improved download robustness with candidate URL retrying and smoother failover between mirrors.
  * Enhanced handling of network failures (DNS/TLS/timeout/connection issues) and more reliable reporting when all options fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->