### PR TITLE
Moved minisign key pair generation into example server

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,31 +291,40 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Install minisign
+      # ── Build .NET components ──────────────────────────────────────────────
+      # The example server is built first because its binary is used as the
+      # signing tool (e2e-keygen / e2e-sign modes) before the C++ updater is compiled.
+
+      - name: Publish setup stub (framework-dependent, win-x64)
         shell: pwsh
         run: |
-          # Chocolatey ships a pre-0.9 binary that lacks the -W (passwordless) flag.
-          # Download 0.12 directly from the upstream GitHub release instead.
-          $zip = Join-Path $env:RUNNER_TEMP 'minisign.zip'
-          Invoke-WebRequest `
-            -Uri 'https://github.com/jedisct1/minisign/releases/download/0.12/minisign-0.12-win64.zip' `
-            -OutFile $zip
-          Expand-Archive -Path $zip `
-            -DestinationPath (Join-Path $env:RUNNER_TEMP 'minisign') -Force
-          $exe = Join-Path $env:RUNNER_TEMP 'minisign' 'minisign-win64' 'x86_64' 'minisign.exe'
-          Add-Content -Path $env:GITHUB_PATH -Value (Split-Path $exe)
+          dotnet publish examples\e2e-setup-stub\e2e-setup-stub.csproj `
+            -c Release -r win-x64 --no-self-contained `
+            -o stub-publish
+
+      - name: Build example server
+        shell: pwsh
+        run: dotnet build examples\server\server.csproj -c Release --nologo
 
       # ── Ephemeral signing key (generated fresh every run, never committed) ──
+      # The server binary's e2e-keygen mode (backed by minisign-net) generates the
+      # key pair, writes e2e.key / e2e.pub to RUNNER_TEMP, and prints the base64
+      # public key string to stdout so it can be compiled into the updater.
 
-      - name: Generate ephemeral minisign keypair
+      - name: Generate ephemeral minisign keypair via server binary
         shell: pwsh
         run: |
-          minisign -G -W `
-            -p "$env:RUNNER_TEMP\e2e.pub" `
-            -s "$env:RUNNER_TEMP\e2e.key"
-          # Second line of the .pub file is the raw base64 key string (RWS...)
-          $pubKey = (Get-Content "$env:RUNNER_TEMP\e2e.pub")[1]
-          "E2E_MINISIGN_PUBKEY=$pubKey" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $serverDll = "examples\server\bin\Release\net10.0\server.dll"
+          # Use a fixed ephemeral password; never committed — only lives in this runner.
+          $password = 'vicius-e2e-ephemeral'
+          $env:E2E_MINISIGN_PASSWORD = $password
+          # e2e-keygen writes e2e.key / e2e.pub to the output dir and prints the
+          # base64 public key (RW... token) to stdout.
+          $pubKey = dotnet $serverDll e2e-keygen $env:RUNNER_TEMP
+          $secKey = Join-Path $env:RUNNER_TEMP 'e2e.key'
+          "E2E_MINISIGN_PUBKEY=$pubKey"   | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "E2E_MINISIGN_SECKEY=$secKey"   | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "E2E_MINISIGN_PASSWORD=$password" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Write signed-manifest variant customize header
         shell: pwsh
@@ -351,19 +360,6 @@ jobs:
             /p:UpdaterName="e2eSig_Sig_Updater" `
             /p:CustomIncludes="$env:GITHUB_WORKSPACE\tests\e2e\include\sig\" `
             /p:CI=true
-
-      # ── Build .NET components ──────────────────────────────────────────────
-
-      - name: Publish setup stub (framework-dependent, win-x64)
-        shell: pwsh
-        run: |
-          dotnet publish examples\e2e-setup-stub\e2e-setup-stub.csproj `
-            -c Release -r win-x64 --no-self-contained `
-            -o stub-publish
-
-      - name: Build example server (for --no-build run in driver)
-        shell: pwsh
-        run: dotnet build examples\server\server.csproj -c Release --nologo
 
       # ── Negative-control artifact ──────────────────────────────────────────
 
@@ -443,12 +439,14 @@ jobs:
           $manifest = $manifestObj | ConvertTo-Json -Depth 10
 
           $manifestPath = Join-Path $dir 'SignedManifest\updates.json'
-          # Write with LF line endings so minisign signs exactly the bytes the
+          # Write with LF line endings so the signing tool signs exactly the bytes the
           # server will serve (the endpoint uses File.OpenRead, not text mode).
           [System.IO.File]::WriteAllText($manifestPath, $manifest.Replace("`r`n", "`n"))
 
-          # Sign with the ephemeral key (produces updates.json.minisig next to the file)
-          minisign -S -s "$env:RUNNER_TEMP\e2e.key" -m $manifestPath
+          # Sign with the server binary's e2e-sign mode (backed by minisign-net).
+          # Produces updates.json.minisig next to the file.
+          $serverDll = "$env:GITHUB_WORKSPACE\examples\server\bin\Release\net10.0\server.dll"
+          dotnet $serverDll e2e-sign $manifestPath
 
           # Tampered copy: mutate one field so the original signature no longer
           # covers the body — the client should return NV_E_SERVER_RESPONSE=104.
@@ -465,12 +463,14 @@ jobs:
         shell: pwsh
         run: |
           pwsh tests\e2e\run-e2e.ps1 `
-            -MainBin      "bin\x64\e2e_Main_Updater.exe" `
-            -SigBin       "bin\x64\e2eSig_Sig_Updater.exe" `
-            -ProdBin      "prod-artifact\x64\example_Demo_Updater.exe" `
-            -ArtifactsDir "$env:E2E_ARTIFACTS_DIR" `
-            -ServerDir    "examples\server" `
-            -LogDir       "e2e-logs"
+            -MainBin           "bin\x64\e2e_Main_Updater.exe" `
+            -SigBin            "bin\x64\e2eSig_Sig_Updater.exe" `
+            -ProdBin           "prod-artifact\x64\example_Demo_Updater.exe" `
+            -ArtifactsDir      "$env:E2E_ARTIFACTS_DIR" `
+            -ServerDir         "examples\server" `
+            -LogDir            "e2e-logs" `
+            -MinisignSecKey    "$env:E2E_MINISIGN_SECKEY" `
+            -MinisignPassword  "$env:E2E_MINISIGN_PASSWORD"
 
       - name: Upload E2E logs
         if: always()

--- a/examples/server/Endpoints/E2E/E2EDynamicSignedManifestEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EDynamicSignedManifestEndpoint.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Converters;
+using Nefarius.Vicius.Abstractions.Models;
+using Nefarius.Vicius.Example.Server.Services;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: manifest built and signed at request time by the server using minisign-net.
+///     Two products are served under this endpoint:
+///     <list type="bullet">
+///         <item>
+///             <c>DynamicSignedManifest</c> — canonical manifest + valid signature; updater should
+///             succeed (exit 203).
+///         </item>
+///         <item>
+///             <c>DynamicTamperedManifest</c> — tampered manifest body served together with a
+///             signature that covers the <em>untampered</em> body; updater should reject the manifest
+///             (exit 104).
+///         </item>
+///     </list>
+///     Routes handled (manufacturer <c>e2eSigDyn</c>):
+///     <list type="bullet">
+///         <item><c>GET api/e2eSigDyn/{product}/updates.json</c></item>
+///         <item><c>GET api/e2eSigDyn/{product}/updates.json.minisig</c></item>
+///     </list>
+///     Only active when <c>VICIUS_E2E=1</c> and the signer is configured.
+/// </summary>
+internal sealed class E2EDynamicSignedManifestEndpoint : Endpoint<E2EDynamicSignedManifestRequest>
+{
+    // Serializer options that produce the same bytes the FastEndpoints pipeline uses globally:
+    //   - camelCase property names
+    //   - null values omitted
+    //   - DateTimeOffset as ISO 8601 UTC string
+    //   - enums as their string names
+    // These options must be used for both serving the manifest and computing the signature so that
+    // the bytes that are signed == the bytes that are served.
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters =
+        {
+            new DateTimeOffsetConverter(),
+            new JsonStringEnumConverter()
+        }
+    };
+
+    private readonly MinisignManifestSigner _signer;
+
+    public E2EDynamicSignedManifestEndpoint(MinisignManifestSigner signer)
+    {
+        _signer = signer;
+    }
+
+    public override void Configure()
+    {
+        Get("api/e2eSigDyn/{Product}/{Filename}");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(E2EDynamicSignedManifestRequest req, CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (!_signer.IsConfigured)
+        {
+            await Send.ErrorsAsync(503, ct);
+            return;
+        }
+
+        bool isManifest = req.Filename == "updates.json";
+        bool isMinisig = req.Filename == "updates.json.minisig";
+        bool isDynamicSigned = req.Product == "DynamicSignedManifest";
+        bool isDynamicTampered = req.Product == "DynamicTamperedManifest";
+
+        if (!isManifest && !isMinisig)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (!isDynamicSigned && !isDynamicTampered)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload.zip' not found in artifacts directory", 500);
+
+        // Build the canonical UpdateResponse. PublishedAt is pinned so that the manifest bytes
+        // are deterministic across manifest and minisig requests within one server run.
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse canonical = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Dynamic Signing Test",
+                WindowTitle = "E2E Dynamic Signed Manifest Updater",
+                SignatureVerificationMode = SignatureVerificationMode.Disabled
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Dynamic Signed Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/artifacts/payload.zip",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    }
+                }
+            }
+        };
+
+        // Serialize once; all requests (manifest + minisig for either product) use these bytes
+        // to compute or verify the signature.
+        byte[] canonicalBytes = JsonSerializer.SerializeToUtf8Bytes(canonical, SerializerOptions);
+
+        // The .minisig sidecar always covers the canonical (untampered) bytes.
+        // For DynamicTamperedManifest the client receives a mutated body but the original signature
+        // → verification fails exactly as intended.
+        if (isMinisig)
+        {
+            byte[] sig = _signer.SignDetached(canonicalBytes);
+            HttpContext.Response.ContentType = "application/octet-stream";
+            HttpContext.Response.StatusCode = 200;
+            await HttpContext.Response.Body.WriteAsync(sig, ct);
+            return;
+        }
+
+        // Serve the manifest body. Tampered variant mutates the version string in raw JSON so
+        // the change cannot be missed without touching the signature path.
+        byte[] body = isDynamicTampered
+            ? Encoding.UTF8.GetBytes(
+                Encoding.UTF8.GetString(canonicalBytes).Replace("\"version\":\"2.0.0\"", "\"version\":\"9.9.9\""))
+            : canonicalBytes;
+
+        HttpContext.Response.ContentType = "application/json";
+        HttpContext.Response.StatusCode = 200;
+        await HttpContext.Response.Body.WriteAsync(body, ct);
+    }
+}
+
+internal sealed class E2EDynamicSignedManifestRequest
+{
+    public string Product { get; set; } = string.Empty;
+    public string Filename { get; set; } = string.Empty;
+}

--- a/examples/server/Program.cs
+++ b/examples/server/Program.cs
@@ -3,11 +3,60 @@ using System.Text.Json.Serialization;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 
+using Minisign;
+
 using Nefarius.Utilities.AspNetCore;
 using Nefarius.Vicius.Abstractions.Converters;
 using Nefarius.Vicius.Example.Server.Services;
 
-WebApplicationBuilder bld = WebApplication.CreateBuilder().Setup();
+// ── One-off CLI modes for E2E tooling (no web server started) ────────────────
+//
+// e2e-keygen <outDir>
+//   Generates a fresh minisign key pair using the password from E2E_MINISIGN_PASSWORD,
+//   writes e2e.key / e2e.pub to <outDir>, and prints the base64 public key string
+//   (the second line of the .pub file, i.e. the RW... token) to stdout.
+//   CI reads this value and compiles it into the updater as NV_MANIFEST_PUBLIC_KEY.
+//
+// e2e-sign <manifestPath>
+//   Signs <manifestPath> using the key at E2E_MINISIGN_SECKEY decrypted with
+//   E2E_MINISIGN_PASSWORD.  Produces <manifestPath>.minisig beside the manifest.
+//   Replaces the minisign CLI's "minisign -S" step for the static E2E scenarios.
+//
+if (args.Length >= 2 && args[0] == "e2e-keygen")
+{
+    string outDir = args[1];
+    string password = Environment.GetEnvironmentVariable("E2E_MINISIGN_PASSWORD")
+                      ?? throw new InvalidOperationException("E2E_MINISIGN_PASSWORD is not set.");
+
+    Directory.CreateDirectory(outDir);
+    Core.GenerateKeyPair(password, writeOutputFiles: true, outputFolder: outDir, keyPairFileName: "e2e");
+
+    // The .pub file written by minisign-net has two lines:
+    //   untrusted comment: ...
+    //   <base64 pubkey>   ← this is the RW... token compiled into NV_MANIFEST_PUBLIC_KEY
+    string pubKeyFile = Path.Combine(outDir, "e2e.pub");
+    string pubKeyLine = File.ReadLines(pubKeyFile).Skip(1).First();
+    Console.WriteLine(pubKeyLine);
+    return 0;
+}
+
+if (args.Length >= 2 && args[0] == "e2e-sign")
+{
+    string manifestPath = args[1];
+    string secKeyPath = Environment.GetEnvironmentVariable("E2E_MINISIGN_SECKEY")
+                        ?? throw new InvalidOperationException("E2E_MINISIGN_SECKEY is not set.");
+    string password = Environment.GetEnvironmentVariable("E2E_MINISIGN_PASSWORD")
+                      ?? throw new InvalidOperationException("E2E_MINISIGN_PASSWORD is not set.");
+
+    var key = Core.LoadPrivateKeyFromFile(secKeyPath, password);
+    Core.SignHashed(manifestPath, key);
+    Console.WriteLine($"Signed: {manifestPath}.minisig");
+    return 0;
+}
+
+// ── Normal web-server startup ─────────────────────────────────────────────────
+
+WebApplicationBuilder bld = WebApplication.CreateBuilder(args).Setup();
 bld.Services.AddFastEndpoints().SwaggerDocument(o =>
 {
     // you will not need this but it is nice to have a summary
@@ -27,6 +76,7 @@ bld.Services.AddFastEndpoints().SwaggerDocument(o =>
 
 bld.Services.AddMemoryCache();
 bld.Services.AddSingleton<GitHubApiService>();
+bld.Services.AddSingleton<MinisignManifestSigner>();
 
 WebApplication app = bld.Build().Setup();
 
@@ -42,3 +92,4 @@ app.UseFastEndpoints(c =>
 }).UseSwaggerGen();
 
 app.Run();
+return 0;

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -54,9 +54,54 @@ Tag it with your own registry, of course 😉
 docker build --push -t nefarius.azurecr.io/nefarius-vicius-server:latest .
 ```
 
+---
+
+## Dynamic manifest signing (E2E / minisign-net)
+
+The server binary doubles as a one-shot signing tool for E2E workflows.
+No external `minisign` CLI is needed — all signing is done via
+[minisign-net](https://github.com/bitbeans/minisign-net) (NuGet package).
+
+### One-off CLI modes
+
+Both modes exit immediately without starting the web server.
+
+```PowerShell
+# Generate an ephemeral Ed25519 key pair. Reads E2E_MINISIGN_PASSWORD.
+# Writes e2e.key / e2e.pub to <outDir> and prints the base64 public key
+# (the RW... token) to stdout so it can be compiled into NV_MANIFEST_PUBLIC_KEY.
+$env:E2E_MINISIGN_PASSWORD = 'your-password'
+dotnet examples/server/bin/Release/net10.0/server.dll e2e-keygen <outDir>
+
+# Sign a manifest file. Reads E2E_MINISIGN_SECKEY and E2E_MINISIGN_PASSWORD.
+# Produces <manifestPath>.minisig beside the manifest.
+$env:E2E_MINISIGN_SECKEY   = '<outDir>/e2e.key'
+$env:E2E_MINISIGN_PASSWORD = 'your-password'
+dotnet examples/server/bin/Release/net10.0/server.dll e2e-sign <manifestPath>
+```
+
+### Runtime dynamic signing endpoint
+
+When the web server starts with `E2E_MINISIGN_SECKEY` and `E2E_MINISIGN_PASSWORD`
+set, `MinisignManifestSigner` loads the private key and enables two additional E2E
+routes under the `e2eSigDyn` manufacturer prefix:
+
+| Route | Description |
+|---|---|
+| `GET api/e2eSigDyn/DynamicSignedManifest/updates.json` | Builds and serves the canonical manifest JSON |
+| `GET api/e2eSigDyn/DynamicSignedManifest/updates.json.minisig` | Returns the Ed25519 signature over the canonical bytes |
+| `GET api/e2eSigDyn/DynamicTamperedManifest/updates.json` | Serves a mutated (tampered) manifest body |
+| `GET api/e2eSigDyn/DynamicTamperedManifest/updates.json.minisig` | Returns the signature over the *untampered* body — so client verification fails |
+
+The signature format is minisign's prehashed "ED" mode (Ed25519 over BLAKE2b-512),
+which is interoperable with the C++ client's `VerifyManifestSignature` implementation.
+
+---
+
 ## Sources & 3rd party credits
 
 - [NJsonSchema for .NET](https://github.com/RicoSuter/NJsonSchema)
 - [FastEndpoints](https://fast-endpoints.com/)
+- [minisign-net](https://github.com/bitbeans/minisign-net)
 - [Nefarius.Utilities.AspNetCore](https://github.com/nefarius/Nefarius.Utilities.AspNetCore)
 - [Nefarius.Vicius.Abstractions](../../abstractions/) (co-located in this repo)

--- a/examples/server/Services/MinisignManifestSigner.cs
+++ b/examples/server/Services/MinisignManifestSigner.cs
@@ -1,0 +1,82 @@
+using Minisign;
+using Minisign.Models;
+
+namespace Nefarius.Vicius.Example.Server.Services;
+
+/// <summary>
+///     Singleton service that holds a loaded minisign private key and can sign manifest payloads
+///     in-memory at request time. Configured via environment variables:
+///     <list type="bullet">
+///         <item><c>E2E_MINISIGN_SECKEY</c> — path to the <c>.key</c> file.</item>
+///         <item><c>E2E_MINISIGN_PASSWORD</c> — password used to decrypt the key.</item>
+///     </list>
+///     When either variable is absent the service is unconfigured and <see cref="IsConfigured" />
+///     returns <c>false</c>.
+/// </summary>
+internal sealed class MinisignManifestSigner
+{
+    private readonly MinisignPrivateKey? _privateKey;
+    private readonly Lock _lock = new();
+
+    public MinisignManifestSigner(ILogger<MinisignManifestSigner> logger)
+    {
+        string? secKeyPath = Environment.GetEnvironmentVariable("E2E_MINISIGN_SECKEY");
+        string? password = Environment.GetEnvironmentVariable("E2E_MINISIGN_PASSWORD");
+
+        if (string.IsNullOrEmpty(secKeyPath) || string.IsNullOrEmpty(password))
+        {
+            logger.LogInformation(
+                "MinisignManifestSigner: E2E_MINISIGN_SECKEY or E2E_MINISIGN_PASSWORD not set; dynamic signing disabled.");
+            return;
+        }
+
+        if (!File.Exists(secKeyPath))
+        {
+            logger.LogWarning(
+                "MinisignManifestSigner: key file '{Path}' not found; dynamic signing disabled.", secKeyPath);
+            return;
+        }
+
+        try
+        {
+            _privateKey = Core.LoadPrivateKeyFromFile(secKeyPath, password);
+            logger.LogInformation("MinisignManifestSigner: private key loaded from '{Path}'.", secKeyPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "MinisignManifestSigner: failed to load private key; dynamic signing disabled.");
+        }
+    }
+
+    /// <summary>Returns <c>true</c> when a private key was successfully loaded.</summary>
+    public bool IsConfigured => _privateKey is not null;
+
+    /// <summary>
+    ///     Signs <paramref name="manifestBytes" /> with the pre-loaded private key using the prehashed
+    ///     ("ED", Ed25519 over BLAKE2b-512) minisign format and returns the raw <c>.minisig</c> sidecar bytes.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the signer is not configured.</exception>
+    public byte[] SignDetached(byte[] manifestBytes)
+    {
+        if (_privateKey is null)
+            throw new InvalidOperationException("MinisignManifestSigner is not configured.");
+
+        // Core.SignHashed requires a real file path; write a temp file, sign it, read the sidecar.
+        string tmpFile = Path.Combine(Path.GetTempPath(), $"vicius-manifest-{Guid.NewGuid():N}.json");
+        string sigFile = tmpFile + ".minisig";
+        try
+        {
+            lock (_lock)
+            {
+                File.WriteAllBytes(tmpFile, manifestBytes);
+                Core.SignHashed(tmpFile, _privateKey);
+                return File.ReadAllBytes(sigFile);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tmpFile)) File.Delete(tmpFile);
+            if (File.Exists(sigFile)) File.Delete(sigFile);
+        }
+    }
+}

--- a/examples/server/server.csproj
+++ b/examples/server/server.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
         <PackageReference Include="FastEndpoints" Version="8.2.0" />
         <PackageReference Include="FastEndpoints.Swagger" Version="8.2.0" />
+        <PackageReference Include="minisign-net" Version="1.0.0" />
         <PackageReference Include="Nefarius.Utilities.AspNetCore" Version="2.9.0" />
         <ProjectReference Include="..\..\abstractions\src\Nefarius.Vicius.Abstractions.csproj" />
         <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.6.1" />

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -56,7 +56,15 @@ param(
     [Parameter(Mandatory)]
     [string] $ServerDir,
 
-    [string] $LogDir = (Join-Path $PSScriptRoot 'e2e-logs')
+    [string] $LogDir = (Join-Path $PSScriptRoot 'e2e-logs'),
+
+    # Optional: path to the minisign .key file used by the server for dynamic manifest signing.
+    # When supplied together with -MinisignPassword the DynamicSignedManifest / DynamicTamperedManifest
+    # scenarios are enabled.
+    [string] $MinisignSecKey = '',
+
+    # Optional: password for the minisign secret key supplied via -MinisignSecKey.
+    [string] $MinisignPassword = ''
 )
 
 Set-StrictMode -Version Latest
@@ -79,6 +87,8 @@ function Start-E2EServer {
     $env:E2E_ARTIFACTS_DIR = $ArtifactsDir
     $env:ASPNETCORE_URLS   = 'http://localhost:5200'
     $env:ASPNETCORE_ENVIRONMENT = 'Development'
+    if ($MinisignSecKey)    { $env:E2E_MINISIGN_SECKEY   = $MinisignSecKey }
+    if ($MinisignPassword)  { $env:E2E_MINISIGN_PASSWORD = $MinisignPassword }
 
     # Run the pre-built server DLL directly; avoids 'dotnet run' profile
     # ambiguity and works reliably with -RedirectStandard* on PS 7.
@@ -368,6 +378,32 @@ try {
             SkipSelfUpdate = $true
         },
 
+        # ── Dynamic server-side signing (minisign-net) scenarios ─────────────
+        # Reuse $SigBin (same compiled NV_MANIFEST_PUBLIC_KEY); the server signs
+        # the manifest at request time via MinisignManifestSigner.
+        # These scenarios are skipped when -MinisignSecKey / -MinisignPassword are absent.
+
+        @{
+            Name           = 'DynamicSignedManifest'
+            SourceBin      = $SigBin
+            ExeName        = 'e2eSigDyn_DynamicSignedManifest_Updater.exe'
+            LocalVersion   = '0.0.1'
+            ExpectedExit   = 203
+            SkipSelfUpdate = $true
+            SkipWhen       = (-not $MinisignSecKey -or -not $MinisignPassword)
+        },
+        @{
+            # Server returns a tampered manifest body but signs the canonical body,
+            # so the client's Ed25519 verification fails → NV_E_SERVER_RESPONSE (104).
+            Name           = 'DynamicTamperedManifest'
+            SourceBin      = $SigBin
+            ExeName        = 'e2eSigDyn_DynamicTamperedManifest_Updater.exe'
+            LocalVersion   = '0.0.1'
+            ExpectedExit   = 104
+            SkipSelfUpdate = $true
+            SkipWhen       = (-not $MinisignSecKey -or -not $MinisignPassword)
+        },
+
         # ── Version parsing / 4-segment revision scenarios ───────────────────
         # Reuse HappyZip (serves 2.0.0) by varying --force-local-version only.
 
@@ -545,6 +581,12 @@ try {
     )
 
     foreach ($s in $scenarios) {
+        if ($s.ContainsKey('SkipWhen') -and $s.SkipWhen) {
+            Write-Host "  SKIP  $($s.Name) (prerequisites not available)"
+            $results.Add(@{ Name = $s.Name; Passed = $true; Expected = $s.ExpectedExit; Got = $null; LogFailures = @(); Skipped = $true })
+            continue
+        }
+
         $invokeParams = @{
             Name            = $s.Name
             SourceBin       = $s.SourceBin
@@ -567,9 +609,11 @@ try {
     Stop-E2EServer $serverJob
 
     # Restore env vars cleared on finish
-    Remove-Item Env:\VICIUS_E2E        -ErrorAction SilentlyContinue
-    Remove-Item Env:\E2E_ARTIFACTS_DIR -ErrorAction SilentlyContinue
-    Remove-Item Env:\ASPNETCORE_URLS   -ErrorAction SilentlyContinue
+    Remove-Item Env:\VICIUS_E2E              -ErrorAction SilentlyContinue
+    Remove-Item Env:\E2E_ARTIFACTS_DIR       -ErrorAction SilentlyContinue
+    Remove-Item Env:\ASPNETCORE_URLS         -ErrorAction SilentlyContinue
+    Remove-Item Env:\E2E_MINISIGN_SECKEY     -ErrorAction SilentlyContinue
+    Remove-Item Env:\E2E_MINISIGN_PASSWORD   -ErrorAction SilentlyContinue
 }
 
 # ---------------------------------------------------------------------------
@@ -578,9 +622,15 @@ try {
 
 Write-Header 'E2E Test Summary'
 
-$passed = 0
-$failed = 0
+$passed  = 0
+$failed  = 0
+$skipped = 0
 foreach ($r in $results) {
+    if ($r.ContainsKey('Skipped') -and $r.Skipped) {
+        Write-Host "  -  $($r.Name) (skipped)"
+        $skipped++
+        continue
+    }
     $icon   = if ($r.Passed) { '✔' } else { '✘' }
     $detail = if ($r.Passed) { '' } else { " (got $($r.Got), expected $($r.Expected))" }
     if (-not $r.Passed -and $r.LogFailures.Count -gt 0) {
@@ -591,7 +641,7 @@ foreach ($r in $results) {
 }
 
 Write-Host ''
-Write-Host "  Passed: $passed   Failed: $failed"
+Write-Host "  Passed: $passed   Failed: $failed   Skipped: $skipped"
 Write-Host ''
 
 if ($failed -gt 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic manifest signing support in the example server, including generated signed manifests and a tampered-manifest scenario for verification checks.
  * Added command-line modes for generating signing keys and signing manifests directly from the server tooling.

* **Bug Fixes**
  * Improved end-to-end test handling to better report skipped scenarios and clean up signing-related environment settings.

* **Chores**
  * Updated the example server documentation and CI workflow to support the new signing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->