### PR TITLE
Added exit code to message and help action map

### DIFF
--- a/abstractions/src/Models/UpdateRelease.cs
+++ b/abstractions/src/Models/UpdateRelease.cs
@@ -6,6 +6,38 @@ using NJsonSchema.Annotations;
 namespace Nefarius.Vicius.Abstractions.Models;
 
 /// <summary>
+///     Per-exit-code UI message entry used in <see cref="ExitCodeCheck.Messages" />.
+/// </summary>
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public sealed class ExitCodeMessage
+{
+    /// <summary>
+    ///     The message displayed in the updater UI when this exit code is encountered.
+    /// </summary>
+    [Required]
+    public string Message { get; set; } = null!;
+
+    /// <summary>
+    ///     When <c>true</c>, this exit code is treated as a success condition even if it is
+    ///     absent from <see cref="ExitCodeCheck.SuccessCodes" />.
+    /// </summary>
+    public bool? IsSuccess { get; set; }
+
+    /// <summary>
+    ///     Optional URL opened by the help/more-info button shown alongside the message.
+    /// </summary>
+    public string? HelpUrl { get; set; }
+
+    /// <summary>
+    ///     Optional custom label for the help/more-info button.
+    ///     Defaults to <c>"Open help page"</c> when omitted.
+    /// </summary>
+    public string? ButtonText { get; set; }
+}
+
+/// <summary>
 ///     Setup exit code parameters.
 /// </summary>
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
@@ -25,6 +57,13 @@ public sealed class ExitCodeCheck
     /// </summary>
     [Required]
     public List<int> SuccessCodes { get; } = new();
+
+    /// <summary>
+    ///     Optional per-exit-code UI messages, keyed by decimal exit code string (e.g. <c>"3010"</c>).
+    ///     An entry with <see cref="ExitCodeMessage.IsSuccess" /> set to <c>true</c> also promotes that
+    ///     code to a success condition without requiring it to appear in <see cref="SuccessCodes" />.
+    /// </summary>
+    public Dictionary<string, ExitCodeMessage>? Messages { get; set; }
 }
 
 /// <summary>

--- a/examples/server/Endpoints/DefaultDemoEndpoint.cs
+++ b/examples/server/Endpoints/DefaultDemoEndpoint.cs
@@ -133,6 +133,8 @@ internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
                               - Remind me tomorrow button (start page)
                               - Back / Cancel navigation
                               - Successful exit-code mapping (0 and 3010 both count as success)
+                              - Custom exit-code message for 3010: reboot-required notice with help button
+                              - Custom exit-code message for 1602: user-cancelled notice
 
                               ## Scrollbar test
 
@@ -169,7 +171,34 @@ internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
                         SuccessCodes =
                         {
                             0,    // regular success
-                            3010  // success, reboot required
+                            3010  // success, reboot required (also covered by the message map below)
+                        },
+                        // Demonstrates the exit-code message map: when the installer exits with
+                        // 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) the updater shows this notice
+                        // instead of closing silently, and offers a help button.
+                        Messages = new Dictionary<string, ExitCodeMessage>
+                        {
+                            // 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
+                            ["3010"] = new ExitCodeMessage
+                            {
+                                IsSuccess = true,
+                                Message =
+                                    "The update was installed successfully, but a system reboot is required " +
+                                    "before the new version becomes fully active.\n\n" +
+                                    "Please save your work and restart Windows at your earliest convenience.",
+                                HelpUrl = "https://docs.nefarius.at/projects/Vicius/Setup-Exit-Codes/",
+                                ButtonText = "Learn more about the reboot requirement"
+                            },
+                            // 1602 = ERROR_INSTALL_USEREXIT — user cancelled the installer
+                            ["1602"] = new ExitCodeMessage
+                            {
+                                Message =
+                                    "The installation was cancelled before it could complete. " +
+                                    "No changes have been made to your system.\n\n" +
+                                    "You can retry the update at any time by running the updater again.",
+                                HelpUrl = "https://docs.nefarius.at/projects/Vicius/Setup-Exit-Codes/",
+                                ButtonText = "More information"
+                            }
                         }
                     }
                 }

--- a/examples/server/Endpoints/ExitCodeMessageExample.cs
+++ b/examples/server/Endpoints/ExitCodeMessageExample.cs
@@ -1,0 +1,86 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints;
+
+/// <summary>
+///     Demonstrates the exit-code message map feature (issue #24).
+///
+///     When the MSI installer exits with code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) the
+///     updater normally treats it as plain success and closes silently. By adding an entry
+///     to <see cref="ExitCodeCheck.Messages" /> the distributor can instead display a
+///     user-visible notice explaining why a reboot is necessary, with an optional link to
+///     a help article.
+///
+///     The <c>isSuccess: true</c> flag in the message entry promotes code 3010 to a success
+///     condition, so it does not need to be repeated in <see cref="ExitCodeCheck.SuccessCodes" />.
+/// </summary>
+internal sealed class ExitCodeMessageExampleEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/contoso/ExitCodeMessage/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("Examples"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "Contoso App",
+                WindowTitle = "Contoso App Updater",
+                Detection = new RegistryValueConfig
+                {
+                    Hive = RegistryHive.HKLM,
+                    Key = @"SOFTWARE\Contoso\App",
+                    Value = "Version"
+                }
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "Contoso App 2.0",
+                    PublishedAt = DateTimeOffset.Parse("2024-06-01"),
+                    Version = System.Version.Parse("2.0.0"),
+                    Summary = """
+                              ## Contoso App 2.0
+
+                              This release requires a reboot to complete the installation.
+
+                              After clicking **Finish** in the updater, please save your work and restart Windows.
+                              """,
+                    DownloadUrl = "https://example.com/contoso-app-2.0-setup.msi",
+                    LaunchArguments = "/norestart",
+                    ExitCode = new ExitCodeCheck
+                    {
+                        // Code 0 is implicitly the default success; 3010 is promoted to success
+                        // via the Messages map entry below (IsSuccess = true) so it doesn't need
+                        // to be listed here explicitly — though listing both is also valid.
+                        SuccessCodes = { 0 },
+                        Messages = new Dictionary<string, ExitCodeMessage>
+                        {
+                            // 3010 = ERROR_SUCCESS_REBOOT_REQUIRED (MSI "success, reboot required")
+                            ["3010"] = new ExitCodeMessage
+                            {
+                                IsSuccess = true,
+                                Message =
+                                    "The update was installed successfully. A system reboot is required " +
+                                    "before the new version becomes active. Please save your work and " +
+                                    "restart Windows at your earliest convenience.",
+                                HelpUrl = "https://docs.contoso.example/app/update-reboot",
+                                ButtonText = "Learn more about the reboot requirement"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -488,7 +488,7 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
 
         if (!success && check.messages.has_value())
         {
-            if (const auto it = check.messages->find(std::to_string(exitCode));
+            if (const auto it = check.messages->find(std::to_string(static_cast<int>(exitCode)));
                 it != check.messages->end() && it->second.isSuccess.value_or(false))
             {
                 spdlog::debug("Exit code {} promoted to success via message map", exitCode);

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -470,20 +470,31 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
     //
     if (const auto exitCodeCheck = this->ExitCodeCheck(); exitCodeCheck.has_value())
     {
-        const auto [ skipCheck, successCodes ] = exitCodeCheck.value();
+        const auto& check = exitCodeCheck.value();
 
-        if (skipCheck)
+        if (check.skipCheck)
         {
             spdlog::debug("Skipping error code check as per configuration");
 
             success = true;
         }
 
-        if (std::ranges::find(successCodes, exitCode) != successCodes.end())
+        if (std::ranges::find(check.successCodes, static_cast<int>(exitCode)) != check.successCodes.end())
         {
             spdlog::debug("Exit code {} marked as success-condition", exitCode);
 
             success = true;
+        }
+
+        if (!success && check.messages.has_value())
+        {
+            if (const auto it = check.messages->find(std::to_string(exitCode));
+                it != check.messages->end() && it->second.isSuccess.value_or(false))
+            {
+                spdlog::debug("Exit code {} promoted to success via message map", exitCode);
+
+                success = true;
+            }
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1132,6 +1132,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                                 {
                                     spdlog::info("Setup finished successfully; exitCode: {}, win32Error: {}",
                                                  sr.exitCode, sr.win32Error);
+                                    lastExitCode = sr.exitCode;
                                     instStep = DownloadAndInstallStep::InstallSucceeded;
                                 }
                                 else
@@ -1173,19 +1174,43 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 
                         if (lastWin32Error == ERROR_SUCCESS && lastExitCode != 0)
                         {
-                            // Process ran but returned a non-success exit code.
-                            ImGui::Text(ICON_FK_EXCLAMATION_TRIANGLE
-                                        " Error! Installation failed with an unexpected exit code (%lu).",
-                                        lastExitCode);
-
-                            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
-                            if (winapi::IsMsiExecErrorCode(lastExitCode))
+                            // Check for a distributor-configured message for this specific exit code.
+                            const auto mappedMsg = cfg.GetExitCodeMessage(lastExitCode);
+                            if (mappedMsg.has_value() && !mappedMsg->message.empty())
                             {
-                                ImGui::TextWrapped("Setup engine error: %s", winapi::GetLastErrorStdStr(lastExitCode).c_str());
+                                ImGui::Text(ICON_FK_EXCLAMATION_TRIANGLE " Installation failed (exit code %lu).",
+                                            lastExitCode);
+                                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
+                                ImGui::TextWrapped("%s", mappedMsg->message.c_str());
+
+                                if (mappedMsg->helpUrl.has_value())
+                                {
+                                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
+                                    const std::string btnLabel = std::string(ICON_FK_EXTERNAL_LINK " ") +
+                                        mappedMsg->buttonText.value_or("Open help page");
+                                    if (ImGui::Button(btnLabel.c_str()))
+                                    {
+                                        ShellExecuteA(nullptr, "open", mappedMsg->helpUrl->c_str(),
+                                                      nullptr, nullptr, SW_SHOWNORMAL);
+                                    }
+                                }
                             }
                             else
                             {
-                                ImGui::Text("Setup exit code: %lu", lastExitCode);
+                                // Process ran but returned a non-success exit code.
+                                ImGui::Text(ICON_FK_EXCLAMATION_TRIANGLE
+                                            " Error! Installation failed with an unexpected exit code (%lu).",
+                                            lastExitCode);
+
+                                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
+                                if (winapi::IsMsiExecErrorCode(lastExitCode))
+                                {
+                                    ImGui::TextWrapped("Setup engine error: %s", winapi::GetLastErrorStdStr(lastExitCode).c_str());
+                                }
+                                else
+                                {
+                                    ImGui::Text("Setup exit code: %lu", lastExitCode);
+                                }
                             }
                         }
                         else if (const auto details = cfg.GetLastDownloadError(); !details.empty())
@@ -1223,15 +1248,45 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 
                         break;
                     case DownloadAndInstallStep::InstallSucceeded:
-
-                        //ImGui::Text("Done!");
-
-                        // TODO: implement me, right now it simply exits
-
+                    {
                         status = cfg.GetSuccessExitCode(NV_S_UPDATE_FINISHED);
-                        ++currentPage;
+
+                        const auto successMsg = cfg.GetExitCodeMessage(lastExitCode);
+                        if (!successMsg.has_value() || successMsg->message.empty())
+                        {
+                            // No custom message — close immediately (original behaviour).
+                            ++currentPage;
+                            break;
+                        }
+
+                        // A custom message is configured for this exit code: show a success
+                        // screen and let the user dismiss it explicitly.
+                        isCancelDisabled = false;
+
+                        ImGui::Text(ICON_FK_CHECK_CIRCLE " Installation complete.");
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(15));
+                        ImGui::TextWrapped("%s", successMsg->message.c_str());
+
+                        if (successMsg->helpUrl.has_value())
+                        {
+                            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(20));
+                            const std::string btnLabel = std::string(ICON_FK_EXTERNAL_LINK " ") +
+                                successMsg->buttonText.value_or("Open help page");
+                            if (ImGui::Button(btnLabel.c_str()))
+                            {
+                                ShellExecuteA(nullptr, "open", successMsg->helpUrl->c_str(),
+                                              nullptr, nullptr, SW_SHOWNORMAL);
+                            }
+                        }
+
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + SCALED(20));
+                        if (ImGui::Button("Finish"))
+                        {
+                            ++currentPage;
+                        }
 
                         break;
+                    }
                 }
 
                 ImGui::Unindent(leftBorderIndent);

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -532,7 +532,7 @@ namespace models
             }
 
             const auto& map = check->messages.value();
-            const auto it = map.find(std::to_string(exitCode));
+            const auto it = map.find(std::to_string(static_cast<int>(exitCode)));
             if (it == map.end())
             {
                 return std::nullopt;

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -516,6 +516,32 @@ namespace models
         }
 
         /**
+         * \brief Looks up a per-exit-code UI message entry for the given setup exit code.
+         *
+         * Uses the same release-over-instance precedence as ExitCodeCheck().
+         *
+         * \param exitCode The exit code returned by the setup process.
+         * \return The matching ExitCodeMessage, or std::nullopt if none is configured.
+         */
+        std::optional<models::ExitCodeMessage> GetExitCodeMessage(DWORD exitCode)
+        {
+            const auto check = ExitCodeCheck();
+            if (!check.has_value() || !check->messages.has_value())
+            {
+                return std::nullopt;
+            }
+
+            const auto& map = check->messages.value();
+            const auto it = map.find(std::to_string(exitCode));
+            if (it == map.end())
+            {
+                return std::nullopt;
+            }
+
+            return it->second;
+        }
+
+        /**
          * \brief Stores the current timestamp in a volatile registry key.
          */
         void SetPostponeData();

--- a/src/models/UpdateRelease.hpp
+++ b/src/models/UpdateRelease.hpp
@@ -7,6 +7,24 @@
 namespace models
 {
     /**
+     * \brief Per-exit-code UI message entry.
+     */
+    class ExitCodeMessage
+    {
+    public:
+        /** The message displayed in the UI for this exit code */
+        std::string message;
+        /** When true, this exit code is treated as a success condition even if absent from successCodes */
+        std::optional<bool> isSuccess;
+        /** Optional URL opened by the help/more-info button shown alongside the message */
+        std::optional<std::string> helpUrl;
+        /** Optional custom label for the help/more-info button (defaults to "Open help page" if omitted) */
+        std::optional<std::string> buttonText;
+    };
+
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ExitCodeMessage, message, isSuccess, helpUrl, buttonText)
+
+    /**
      * \brief Setup exit code parameters.
      */
     class ExitCodeCheck
@@ -16,9 +34,11 @@ namespace models
         bool skipCheck{false};
         /** The setup exit codes treated as success */
         std::vector<int> successCodes{0};
+        /** Optional per-exit-code UI messages, keyed by decimal exit code string (e.g. "3010") */
+        std::optional<std::unordered_map<std::string, ExitCodeMessage>> messages;
     };
 
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ExitCodeCheck, skipCheck, successCodes)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ExitCodeCheck, skipCheck, successCodes, messages)
 
     /**
      * \brief Details about checksum/hash calculation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-exit-code UI messages, including optional success override, help URL, and custom button text.
  * Install flow can display an exit-code-specific success screen (message + optional help button) when configured.
* **Bug Fixes**
  * Exit codes can now be promoted to success based on configured message settings, improving handling for common reboot-required results.
  * The app now preserves the installer’s final exit code for accurate follow-up messaging on failure and success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->