### PR TITLE
Added support to limit single-instance run

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -76,6 +76,8 @@
 #define NV_S_CLOSED_WHILE_UPDATER_RUNNING            208
 /** The watched product was still running after the maximum wait period; nothing shown or installed, retry on next run. */
 #define NV_S_PRODUCT_IN_USE_TIMEOUT                  209
+/** Another updater process for the same executable path is already running; activation was signaled and this process exited. */
+#define NV_S_INSTANCE_ALREADY_RUNNING                210
 
 /** Hard ceiling on the product-busy wait loop, in minutes. Configured values above this are clamped. */
 #define NV_PRODUCT_IN_USE_MAX_WAIT_MINUTES           180

--- a/src/SingleInstance.cpp
+++ b/src/SingleInstance.cpp
@@ -86,11 +86,9 @@ namespace single_instance
         if (!activateEvent_)
             return false;
 
-        if (WaitForSingleObject(activateEvent_, 0) != WAIT_OBJECT_0)
-            return false;
-
-        ResetEvent(activateEvent_);
-        return true;
+        // Auto-reset event: a successful wait consumes exactly one signal, so a
+        // request that arrives between observation and the next poll stays pending.
+        return WaitForSingleObject(activateEvent_, 0) == WAIT_OBJECT_0;
     }
 
     void Guard::ActivateWindow(HWND hwnd)
@@ -127,7 +125,7 @@ namespace single_instance
         const std::wstring mutexName = MakeObjectName(L"Local\\Nefarius.Vicius.SingleInstance.", hashHex);
         const std::wstring eventName = MakeObjectName(L"Local\\Nefarius.Vicius.Activate.", hashHex);
 
-        HANDLE activateEvent = CreateEventW(nullptr, TRUE /* manual-reset */, FALSE, eventName.c_str());
+        HANDLE activateEvent = CreateEventW(nullptr, FALSE /* auto-reset */, FALSE, eventName.c_str());
         if (!activateEvent)
         {
             return std::unexpected(
@@ -158,6 +156,16 @@ namespace single_instance
             result.status = AcquireStatus::Primary;
             result.guard = Guard(mutex, activateEvent, true);
             return std::move(result);
+        }
+
+        if (waitResult != WAIT_TIMEOUT)
+        {
+            const DWORD err = GetLastError();
+            CloseHandle(mutex);
+            CloseHandle(activateEvent);
+            return std::unexpected(
+                std::format("WaitForSingleObject failed (result={}): {}",
+                            waitResult, winapi::GetLastErrorStdStr(err)));
         }
 
         // Another instance still holds the lock — ask it to focus its UI, then bail.

--- a/src/SingleInstance.cpp
+++ b/src/SingleInstance.cpp
@@ -1,0 +1,180 @@
+#include "pch.h"
+#include "SingleInstance.h"
+#include "Util.h"
+
+namespace
+{
+    constexpr DWORD kTemporaryHandoffWaitMs = 15000;
+
+    std::wstring NormalizeIdentityPath(const std::filesystem::path& identityPath)
+    {
+        wchar_t full[MAX_PATH + 1] = {};
+        const DWORD n = GetFullPathNameW(identityPath.c_str(), MAX_PATH + 1, full, nullptr);
+        std::wstring normalized = (n > 0 && n <= MAX_PATH) ? std::wstring(full, n) : identityPath.wstring();
+
+        CharLowerBuffW(normalized.data(), static_cast<DWORD>(normalized.size()));
+        return normalized;
+    }
+
+    std::string HashIdentityPath(const std::wstring& normalizedPath)
+    {
+        SHA256 alg;
+        alg.add(reinterpret_cast<const char*>(normalizedPath.data()),
+                normalizedPath.size() * sizeof(wchar_t));
+        return alg.getHash();
+    }
+
+    std::wstring MakeObjectName(const wchar_t* prefix, const std::string& hashHex)
+    {
+        return std::wstring(prefix) + ConvertAnsiToWide(hashHex);
+    }
+}
+
+namespace single_instance
+{
+    Guard::Guard(HANDLE mutex, HANDLE activateEvent, bool ownsMutex) noexcept
+        : mutex_(mutex), activateEvent_(activateEvent), ownsMutex_(ownsMutex)
+    {
+    }
+
+    Guard::Guard(Guard&& other) noexcept
+        : mutex_(std::exchange(other.mutex_, nullptr)),
+          activateEvent_(std::exchange(other.activateEvent_, nullptr)),
+          ownsMutex_(std::exchange(other.ownsMutex_, false))
+    {
+    }
+
+    Guard& Guard::operator=(Guard&& other) noexcept
+    {
+        if (this != &other)
+        {
+            Release();
+            mutex_ = std::exchange(other.mutex_, nullptr);
+            activateEvent_ = std::exchange(other.activateEvent_, nullptr);
+            ownsMutex_ = std::exchange(other.ownsMutex_, false);
+        }
+        return *this;
+    }
+
+    Guard::~Guard()
+    {
+        Release();
+    }
+
+    void Guard::Release() noexcept
+    {
+        if (mutex_)
+        {
+            if (ownsMutex_)
+            {
+                ReleaseMutex(mutex_);
+                ownsMutex_ = false;
+            }
+            CloseHandle(mutex_);
+            mutex_ = nullptr;
+        }
+
+        if (activateEvent_)
+        {
+            CloseHandle(activateEvent_);
+            activateEvent_ = nullptr;
+        }
+    }
+
+    bool Guard::ConsumeActivationRequest() const
+    {
+        if (!activateEvent_)
+            return false;
+
+        if (WaitForSingleObject(activateEvent_, 0) != WAIT_OBJECT_0)
+            return false;
+
+        ResetEvent(activateEvent_);
+        return true;
+    }
+
+    void Guard::ActivateWindow(HWND hwnd)
+    {
+        if (!hwnd || !IsWindow(hwnd))
+            return;
+
+        if (IsIconic(hwnd))
+            ShowWindow(hwnd, SW_RESTORE);
+        else
+            ShowWindow(hwnd, SW_SHOW);
+
+        BringWindowToTop(hwnd);
+        SetForegroundWindow(hwnd);
+
+        FLASHWINFO fi = {};
+        fi.cbSize = sizeof(fi);
+        fi.hwnd = hwnd;
+        fi.dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG;
+        fi.uCount = 3;
+        fi.dwTimeout = 0;
+        FlashWindowEx(&fi);
+
+        spdlog::debug("Activated existing updater window {:#x}",
+                      static_cast<std::uintptr_t>(reinterpret_cast<ULONG_PTR>(hwnd)));
+    }
+
+    std::expected<AcquireResult, std::string>
+    AcquireResult::TryAcquire(const std::filesystem::path& identityPath, bool waitForHandoff)
+    {
+        const std::wstring normalized = NormalizeIdentityPath(identityPath);
+        const std::string hashHex = HashIdentityPath(normalized);
+
+        const std::wstring mutexName = MakeObjectName(L"Local\\Nefarius.Vicius.SingleInstance.", hashHex);
+        const std::wstring eventName = MakeObjectName(L"Local\\Nefarius.Vicius.Activate.", hashHex);
+
+        HANDLE activateEvent = CreateEventW(nullptr, TRUE /* manual-reset */, FALSE, eventName.c_str());
+        if (!activateEvent)
+        {
+            return std::unexpected(
+                std::format("CreateEventW failed: {}", winapi::GetLastErrorStdStr()));
+        }
+
+        HANDLE mutex = CreateMutexW(nullptr, FALSE, mutexName.c_str());
+        if (!mutex)
+        {
+            const DWORD err = GetLastError();
+            CloseHandle(activateEvent);
+            return std::unexpected(
+                std::format("CreateMutexW failed: {}", winapi::GetLastErrorStdStr(err)));
+        }
+
+        const DWORD waitMs = waitForHandoff ? kTemporaryHandoffWaitMs : 0;
+        if (waitForHandoff)
+        {
+            spdlog::debug("Temporary copy waiting up to {} ms for single-instance handoff ({})",
+                          waitMs, identityPath.string());
+        }
+
+        const DWORD waitResult = WaitForSingleObject(mutex, waitMs);
+        if (waitResult == WAIT_OBJECT_0 || waitResult == WAIT_ABANDONED)
+        {
+            spdlog::info("Acquired single-instance lock for {}", identityPath.string());
+            AcquireResult result;
+            result.status = AcquireStatus::Primary;
+            result.guard = Guard(mutex, activateEvent, true);
+            return std::move(result);
+        }
+
+        // Another instance still holds the lock — ask it to focus its UI, then bail.
+        if (!SetEvent(activateEvent))
+        {
+            spdlog::warn("Failed to signal activation event: {}", winapi::GetLastErrorStdStr());
+        }
+
+        CloseHandle(mutex);
+        CloseHandle(activateEvent);
+
+        spdlog::info(
+            "Another updater instance is already running for {}; signaling activation and exiting",
+            identityPath.string());
+
+        AcquireResult result;
+        result.status = AcquireStatus::Duplicate;
+        return std::move(result);
+    }
+}

--- a/src/SingleInstance.h
+++ b/src/SingleInstance.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <expected>
+
+namespace single_instance
+{
+    /**
+     * \brief Outcome of attempting to become the sole updater for an identity path.
+     */
+    enum class AcquireStatus
+    {
+        /** This process now owns the single-instance lock. */
+        Primary,
+        /** Another process already owns the lock; activation was signaled. */
+        Duplicate,
+    };
+
+    /**
+     * \brief RAII guard that serializes updater instances for a given executable path.
+     *
+     * Ownership is held for the lifetime of the object. A second process targeting the
+     * same identity signals a named activation event and reports \c Duplicate so the
+     * caller can exit. Temporary-copy handoff may wait briefly for the parent to release
+     * the mutex before deciding.
+     */
+    class Guard
+    {
+    public:
+        Guard() = default;
+        Guard(const Guard&) = delete;
+        Guard& operator=(const Guard&) = delete;
+
+        Guard(Guard&& other) noexcept;
+        Guard& operator=(Guard&& other) noexcept;
+
+        ~Guard();
+
+        /**
+         * \brief Consumes a pending activation request from a duplicate instance.
+         * \return True if a request was pending (and is now cleared).
+         */
+        [[nodiscard]] bool ConsumeActivationRequest() const;
+
+        /** Restores and best-effort focuses \p hwnd (no-op if null / invalid). */
+        static void ActivateWindow(HWND hwnd);
+
+    private:
+        friend struct AcquireResult;
+
+        Guard(HANDLE mutex, HANDLE activateEvent, bool ownsMutex) noexcept;
+
+        void Release() noexcept;
+
+        HANDLE mutex_{nullptr};
+        HANDLE activateEvent_{nullptr};
+        bool ownsMutex_{false};
+    };
+
+    /**
+     * \brief Result of \c TryAcquire — move-only because it may own a \c Guard.
+     */
+    struct AcquireResult
+    {
+        AcquireStatus status{AcquireStatus::Duplicate};
+        /** Present only when \c status is \c Primary. */
+        std::optional<Guard> guard;
+
+        AcquireResult() = default;
+        AcquireResult(const AcquireResult&) = delete;
+        AcquireResult& operator=(const AcquireResult&) = delete;
+        AcquireResult(AcquireResult&&) noexcept = default;
+        AcquireResult& operator=(AcquireResult&&) noexcept = default;
+
+        /**
+         * \brief Attempts to acquire the per-path single-instance lock.
+         * \param identityPath Logical updater path used as the concurrency key
+         *                     (original path for temporary copies).
+         * \param waitForHandoff When true (temporary child), wait briefly for the
+         *                       parent process to release the mutex.
+         * \return On success: Primary with a living Guard, or Duplicate with no Guard.
+         *         On hard failure (kernel object creation), an error string.
+         */
+        [[nodiscard]] static std::expected<AcquireResult, std::string>
+        TryAcquire(const std::filesystem::path& identityPath, bool waitForHandoff);
+    };
+}

--- a/src/SingleInstance.h
+++ b/src/SingleInstance.h
@@ -39,8 +39,8 @@ namespace single_instance
         ~Guard();
 
         /**
-         * \brief Consumes a pending activation request from a duplicate instance.
-         * \return True if a request was pending (and is now cleared).
+         * \brief Consumes one pending activation request from a duplicate instance.
+         * \return True if a request was pending (auto-reset event consumes it).
          */
         [[nodiscard]] bool ConsumeActivationRequest() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "WizardPage.h"
 #include "InstanceConfig.hpp"
 #include "DownloadAndInstall.hpp"
+#include "SingleInstance.h"
 
 #include <curlpp/cURLpp.hpp>
 
@@ -203,6 +204,33 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
             );
         return (int)earlyAbortCode;
     }
+
+#pragma region Single-instance guard
+
+    // Serialize concurrent invocations for the same updater executable path.
+    // Temporary copies wait briefly so the parent can hand off ownership cleanly.
+    std::optional<single_instance::Guard> instanceGuard;
+    {
+        auto acquire = single_instance::AcquireResult::TryAcquire(
+            cfg.GetSingleInstanceIdentityPath(),
+            cfg.IsTemporaryCopy());
+
+        if (!acquire)
+        {
+            spdlog::critical("Failed to acquire single-instance lock: {}", acquire.error());
+            cfg.TryDisplayErrorDialog("Failed to acquire single-instance lock", acquire.error());
+            return NV_E_INVALID_PARAMETERS;
+        }
+
+        if (acquire->status == single_instance::AcquireStatus::Duplicate)
+        {
+            return cfg.GetSuccessExitCode(NV_S_INSTANCE_ALREADY_RUNNING);
+        }
+
+        instanceGuard = std::move(acquire->guard);
+    }
+
+#pragma endregion
 
 #pragma region Install command
 
@@ -665,6 +693,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     ::ShowWindow(hwnd, iCmdShow);
     ::UpdateWindow(hwnd);
 
+    // Honour any activation request that arrived before the window existed.
+    if (instanceGuard && instanceGuard->ConsumeActivationRequest())
+    {
+        single_instance::Guard::ActivateWindow(hwnd);
+    }
+
     ImVec4 clear_color = ImGui::GetStyle().Colors[ImGuiCol_WindowBg];
 
     auto currentPage = WizardPage::Start;
@@ -694,6 +728,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
             cfg.RequestAbortDownload();
             cfg.WaitForDownloadToFinish();
             break;
+        }
+
+        // A second launch of this updater asked us to come to the foreground.
+        if (instanceGuard && instanceGuard->ConsumeActivationRequest())
+        {
+            single_instance::Guard::ActivateWindow(hwnd);
         }
 
         // Handle window being minimized or screen locked

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -185,6 +185,21 @@ namespace models
         semver::version GetAppVersion() const { return appVersion; }
         std::string GetAppFilename() const { return appFilename; }
 
+        /**
+         * \brief Path used as the single-instance concurrency key.
+         *
+         * Temporary copies inherit the parent updater path so the original-to-temporary
+         * handoff stays under one lock instead of opening a parallel run.
+         */
+        [[nodiscard]] std::filesystem::path GetSingleInstanceIdentityPath() const
+        {
+            if (isTemporaryCopy && parentAppPath.has_value())
+                return parentAppPath.value();
+            return appPath;
+        }
+
+        [[nodiscard]] bool IsTemporaryCopy() const { return isTemporaryCopy; }
+
         std::string GetWindowTitle() const { return merged.windowTitle; }
         std::string GetProductName() const { return merged.productName; }
         bool IsRemindButtonHidden() const { return merged.hideRemindButton; }

--- a/src/vīcĭus.vcxproj
+++ b/src/vīcĭus.vcxproj
@@ -362,6 +362,7 @@
     <ClCompile Include="InstanceConfig.Web.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="markdown.cpp" />
+    <ClCompile Include="SingleInstance.cpp" />
     <ClCompile Include="ui.cpp" />
     <ClCompile Include="UpdateRelease.cpp" />
     <ClCompile Include="util.cpp" />
@@ -396,6 +397,7 @@
     <ClInclude Include="UniUtil.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="models\UpdateResponse.hpp" />
+    <ClInclude Include="SingleInstance.h" />
     <ClInclude Include="Util.h" />
     <ClInclude Include="WizardPage.h" />
   </ItemGroup>

--- a/src/vīcĭus.vcxproj.filters
+++ b/src/vīcĭus.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="markdown.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="SingleInstance.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -111,6 +114,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SingleInstance.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CustomizeMe.h">

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -14,6 +14,7 @@
         NV_S_UPDATE_FINISHED = 203
         NV_S_UP_TO_DATE      = 202
         NV_S_SELF_UPDATER    = 201
+        NV_S_INSTANCE_ALREADY_RUNNING = 210
         NV_E_SERVER_RESPONSE = 104
         NV_E_SIGNATURE_INVALID = 116
 
@@ -268,6 +269,124 @@ function Invoke-Scenario {
             Write-Host "  Running post-scenario hook..."
             & $PostScenario
         }
+    }
+}
+
+function Invoke-DuplicateInstanceScenario {
+    param(
+        [string] $SourceBin,
+        [string] $ExeName = 'e2e_HappyZip_Updater.exe'
+    )
+
+    $Name = 'DuplicateInstance'
+    $ExpectedExit = 210  # NV_S_INSTANCE_ALREADY_RUNNING
+    Write-Header "Scenario: $Name (expect exit $ExpectedExit)"
+
+    $workDir = Join-Path $env:TEMP "vicius-e2e-$Name-$(New-Guid)"
+    New-Item -ItemType Directory -Path $workDir | Out-Null
+
+    $exePath = Join-Path $workDir $ExeName
+    Copy-Item -Path $SourceBin -Destination $exePath
+
+    $ownerLog = Join-Path $LogDir "$Name-owner.log"
+    $dupLog   = Join-Path $LogDir "$Name-duplicate.log"
+    $ownerProc = $null
+
+    try {
+        $ownerArgs = @(
+            '--force-local-version', '0.0.1',
+            '--silent-update',
+            '--ignore-busy-state',
+            '--skip-self-update',
+            '--log-to-file', $ownerLog,
+            '--log-level', 'debug'
+        )
+
+        Write-Host "  Starting owner: $ExeName $ownerArgs"
+        $ownerProc = Start-Process `
+            -FilePath $exePath `
+            -ArgumentList $ownerArgs `
+            -PassThru -NoNewWindow
+
+        # Wait until the owner holds the single-instance lock (or exits unexpectedly).
+        $deadline = (Get-Date).AddSeconds(30)
+        $lockAcquired = $false
+        while ((Get-Date) -lt $deadline) {
+            if ($ownerProc.HasExited) {
+                throw "Owner exited early with code $($ownerProc.ExitCode) before acquiring the lock."
+            }
+            if (Test-Path $ownerLog) {
+                $ownerLogText = Get-Content $ownerLog -Raw -ErrorAction SilentlyContinue
+                if ($ownerLogText -like '*Acquired single-instance lock for*') {
+                    $lockAcquired = $true
+                    break
+                }
+            }
+            Start-Sleep -Milliseconds 100
+        }
+
+        if (-not $lockAcquired) {
+            throw 'Owner did not acquire the single-instance lock within 30 seconds.'
+        }
+
+        Write-Host "  Owner holds the lock (PID $($ownerProc.Id)); launching duplicate..."
+        $dupArgs = @(
+            '--force-local-version', '0.0.1',
+            '--silent-update',
+            '--ignore-busy-state',
+            '--skip-self-update',
+            '--log-to-file', $dupLog,
+            '--log-level', 'debug'
+        )
+
+        $dupProc = Start-Process `
+            -FilePath $exePath `
+            -ArgumentList $dupArgs `
+            -Wait -PassThru -NoNewWindow
+        $got = $dupProc.ExitCode
+
+        $logFailures = @()
+        $dupLogText = if (Test-Path $dupLog) {
+            Get-Content $dupLog -Raw -ErrorAction SilentlyContinue
+        } else { '' }
+
+        $expectedLog = 'Another updater instance is already running for'
+        if ($dupLogText -notlike "*$expectedLog*") {
+            $logFailures += "Expected in duplicate log: '$expectedLog'"
+        }
+
+        $passed = ($got -eq $ExpectedExit) -and ($logFailures.Count -eq 0)
+        $status = if ($passed) { 'PASS' } else { 'FAIL' }
+        Write-Host "  $status  exit=$got  expected=$ExpectedExit"
+
+        if (-not $passed) {
+            Write-Host "  Duplicate log tail:"
+            if (Test-Path $dupLog) {
+                Get-Content $dupLog -Tail 30 | ForEach-Object { Write-Host "    $_" }
+            }
+            foreach ($msg in $logFailures) {
+                Write-Host "  LOG ASSERTION FAILED: $msg"
+            }
+        }
+
+        return @{ Name = $Name; Passed = $passed; Expected = $ExpectedExit; Got = $got; LogFailures = $logFailures }
+    }
+    catch {
+        Write-Host "  FAIL  $($_.Exception.Message)"
+        if (Test-Path $ownerLog) {
+            Write-Host "  Owner log tail:"
+            Get-Content $ownerLog -Tail 30 | ForEach-Object { Write-Host "    $_" }
+        }
+        return @{ Name = $Name; Passed = $false; Expected = $ExpectedExit; Got = $null;
+                  LogFailures = @($_.Exception.Message) }
+    }
+    finally {
+        if ($null -ne $ownerProc -and -not $ownerProc.HasExited) {
+            Write-Host "  Stopping owner (PID $($ownerProc.Id))..."
+            Stop-Process -Id $ownerProc.Id -Force -ErrorAction SilentlyContinue
+            $ownerProc.WaitForExit(5000) | Out-Null
+        }
+        Remove-Item -Path $workDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -604,6 +723,10 @@ try {
         }
         $results.Add((Invoke-Scenario @invokeParams))
     }
+
+    # Concurrency regression: second launch of the same executable must exit with
+    # NV_S_INSTANCE_ALREADY_RUNNING (210) after signaling the owner.
+    $results.Add((Invoke-DuplicateInstanceScenario -SourceBin $MainBin))
 
 } finally {
     Stop-E2EServer $serverJob

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -288,11 +288,42 @@ function Invoke-DuplicateInstanceScenario {
     $exePath = Join-Path $workDir $ExeName
     Copy-Item -Path $SourceBin -Destination $exePath
 
+    # Fresh logs each run — stale content must not signal readiness or satisfy assertions.
     $ownerLog = Join-Path $LogDir "$Name-owner.log"
     $dupLog   = Join-Path $LogDir "$Name-duplicate.log"
+    Remove-Item -Path $ownerLog, $dupLog -Force -ErrorAction SilentlyContinue
+
+    # Hold process keeps the owner in the product-in-use wait after lock acquisition
+    # until we release it (after the duplicate has finished).
+    $holdImageName = 'vicius-e2e-hold.exe'
+    $holdExe = Join-Path $workDir $holdImageName
+    Copy-Item -Path (Join-Path $env:SystemRoot 'System32\ping.exe') -Destination $holdExe
+
+    $sidecarPath = Join-Path $workDir ([System.IO.Path]::GetFileNameWithoutExtension($ExeName) + '.json')
+    $sidecar = @{
+        instance = @{
+            authority = 'Local'
+        }
+        shared = @{
+            productBusyDetection = @{
+                imageNames          = @($holdImageName)
+                pollIntervalSeconds = 5
+                maxWaitMinutes      = 5
+            }
+        }
+    } | ConvertTo-Json -Depth 6
+    Set-Content -Path $sidecarPath -Value $sidecar -Encoding utf8
+
     $ownerProc = $null
+    $holdProc  = $null
 
     try {
+        Write-Host "  Starting hold process ($holdImageName)..."
+        $holdProc = Start-Process `
+            -FilePath $holdExe `
+            -ArgumentList '-t', '127.0.0.1' `
+            -PassThru -WindowStyle Hidden
+
         $ownerArgs = @(
             '--force-local-version', '0.0.1',
             '--silent-update',
@@ -329,6 +360,26 @@ function Invoke-DuplicateInstanceScenario {
             throw 'Owner did not acquire the single-instance lock within 30 seconds.'
         }
 
+        # Confirm the owner entered the product-in-use hold (still alive + hold active).
+        $holdDeadline = (Get-Date).AddSeconds(60)
+        $inUseHold = $false
+        while ((Get-Date) -lt $holdDeadline) {
+            if ($ownerProc.HasExited) {
+                throw "Owner exited with code $($ownerProc.ExitCode) before the product-in-use hold."
+            }
+            if (Test-Path $ownerLog) {
+                $ownerLogText = Get-Content $ownerLog -Raw -ErrorAction SilentlyContinue
+                if ($ownerLogText -like '*Product in use*' -or $ownerLogText -like '*matched process by name*') {
+                    $inUseHold = $true
+                    break
+                }
+            }
+            Start-Sleep -Milliseconds 200
+        }
+        if (-not $inUseHold) {
+            throw 'Owner did not enter the product-in-use hold before duplicate launch.'
+        }
+
         Write-Host "  Owner holds the lock (PID $($ownerProc.Id)); launching duplicate..."
         $dupArgs = @(
             '--force-local-version', '0.0.1',
@@ -344,6 +395,18 @@ function Invoke-DuplicateInstanceScenario {
             -ArgumentList $dupArgs `
             -Wait -PassThru -NoNewWindow
         $got = $dupProc.ExitCode
+
+        # Owner must still be holding the lock through the entire duplicate run.
+        if ($ownerProc.HasExited) {
+            throw "Owner exited with code $($ownerProc.ExitCode) before the duplicate finished."
+        }
+
+        # Release the hold only after the duplicate has completed.
+        if ($null -ne $holdProc -and -not $holdProc.HasExited) {
+            Write-Host "  Releasing hold process (PID $($holdProc.Id))..."
+            Stop-Process -Id $holdProc.Id -Force -ErrorAction SilentlyContinue
+            $holdProc.WaitForExit(5000) | Out-Null
+        }
 
         $logFailures = @()
         $dupLogText = if (Test-Path $dupLog) {
@@ -381,6 +444,10 @@ function Invoke-DuplicateInstanceScenario {
                   LogFailures = @($_.Exception.Message) }
     }
     finally {
+        if ($null -ne $holdProc -and -not $holdProc.HasExited) {
+            Stop-Process -Id $holdProc.Id -Force -ErrorAction SilentlyContinue
+            $holdProc.WaitForExit(5000) | Out-Null
+        }
         if ($null -ne $ownerProc -and -not $ownerProc.HasExited) {
             Write-Host "  Stopping owner (PID $($ownerProc.Id))..."
             Stop-Process -Id $ownerProc.Id -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevented multiple updater instances for the same application from running simultaneously.
  * When a duplicate launch occurs, the existing instance is brought to the foreground.
  * Added a dedicated success exit code for duplicate-instance launches (210).
* **Bug Fixes**
  * Improved coordination between temporary updater copies and the primary instance to ensure correct locking.
* **Tests**
  * Added end-to-end coverage that launches concurrent instances, validates the 210 exit code, and checks logs/behavior during contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->