### PR TITLE
Fix archive-extraction crashes and add ZIP edge-case regression coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,6 +385,31 @@ jobs:
           Compress-Archive -Path "$zipSrc\*" `
             -DestinationPath (Join-Path $dir "payload.zip") -Force
 
+          # payload_edge.zip — archive-extraction edge cases: an explicit empty directory
+          # entry plus a normal file, paired with a DeleteIfPresent override (in the
+          # ZipEdgeCases manifest) for a file absent at the destination.
+          # Compress-Archive silently drops empty directories, so the archive is built
+          # directly via ZipArchive to guarantee the "emptydir/" entry is present.
+          Add-Type -AssemblyName System.IO.Compression
+          $edgeZipPath = Join-Path $dir "payload_edge.zip"
+          Remove-Item -Path $edgeZipPath -Force -ErrorAction SilentlyContinue
+          $edgeZip = [System.IO.Compression.ZipFile]::Open($edgeZipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+          try {
+              $edgeZip.CreateEntry("emptydir/") | Out-Null
+              $keepEntry = $edgeZip.CreateEntry("keep.txt")
+              $writer = New-Object System.IO.StreamWriter($keepEntry.Open())
+              try { $writer.Write("E2E zip edge-case payload - normal create/replace entry") }
+              finally { $writer.Dispose() }
+              # Overridden to DeleteIfPresent and absent at the destination (fresh install):
+              # the deployment walk must visit this entry without copying or stamping it.
+              $missingEntry = $edgeZip.CreateEntry("missing-file.txt")
+              $writer2 = New-Object System.IO.StreamWriter($missingEntry.Open())
+              try { $writer2.Write("This file must never be copied to the destination.") }
+              finally { $writer2.Dispose() }
+          } finally {
+              $edgeZip.Dispose()
+          }
+
           # setup.exe — the stub installer (must be a real PE; the apphost qualifies)
           Copy-Item -Path "stub-publish\e2e-setup-stub.exe" `
             -Destination (Join-Path $dir "setup.exe")

--- a/examples/server/Endpoints/E2E/E2EZipEdgeCasesEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EZipEdgeCasesEndpoint.cs
@@ -1,0 +1,82 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: update available, ZIP payload exercising archive-extraction edge cases
+///     that previously crashed or threw an uncaught exception out of the setup task:
+///     <list type="bullet">
+///         <item>an explicit empty directory entry ("emptydir/") in the archive,</item>
+///         <item>a <see cref="ZipExtractFileDisposition.DeleteIfPresent" /> override for a file that
+///             does not exist at the destination (first install), and</item>
+///         <item>a normal file extracted with the default <see cref="ZipExtractFileDisposition.CreateOrReplace" />
+///             disposition.</item>
+///     </list>
+///     Expected updater exit code: <c>NV_S_UPDATE_FINISHED = 203</c>.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2EZipEdgeCasesEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/ZipEdgeCases/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload_edge.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload_edge.zip' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E ZipEdgeCases Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E ZIP Edge Cases Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/artifacts/payload_edge.zip",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    },
+                    ZipExtractDefaultFileDisposition = ZipExtractFileDisposition.CreateOrReplace,
+                    // "missing-file.txt" is never present in a fresh install directory: this override
+                    // exercises the DeleteIfPresent-absent-at-destination path that used to throw.
+                    ZipExtractFileDispositionOverrides = new Dictionary<string, ZipExtractFileDisposition>
+                    {
+                        ["missing-file.txt"] = ZipExtractFileDisposition.DeleteIfPresent
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -160,13 +160,20 @@ std::expected<std::filesystem::path, std::string> models::InstanceConfig::Extrac
             }
         }
 
-        if (outPath.filename().string().back() == '/')
+        // Directory entries are identified by the archive's own entry name (conventionally
+        // trailing-slash), never by re-deriving it from outPath: once the entry name is
+        // "dir/", appending it and normalising can legally yield a path whose filename() is
+        // empty (e.g. "root/dir/"), and calling .back() on that empty string is UB.
+        const std::string_view entryName(stat.name);
+        const bool isDirectoryEntry = !entryName.empty() && entryName.back() == '/';
+
+        try
         {
-            std::filesystem::create_directories(outPath);
-        }
-        else
-        {
-            try
+            if (isDirectoryEntry)
+            {
+                std::filesystem::create_directories(outPath);
+            }
+            else
             {
                 std::filesystem::create_directories(outPath.parent_path());
 
@@ -190,17 +197,18 @@ std::expected<std::filesystem::path, std::string> models::InstanceConfig::Extrac
                     bytesRead += bytesReadThisChunk;
                 }
             }
-            catch (const std::exception& e)
+
+            if ((stat.valid & ZIP_STAT_MTIME) == ZIP_STAT_MTIME)
             {
-                spdlog::error("Failed to open output file `{}` when extracting zip: {}", outPath, e.what());
-                return std::unexpected(std::format("Failed to write zip entry to '{}': {}", outPath.string(), e.what()));
+                const auto sysTime = std::chrono::system_clock::from_time_t(stat.mtime);
+                const auto fileTime = std::chrono::clock_cast<std::chrono::file_clock>(sysTime);
+                std::filesystem::last_write_time(outPath, fileTime);
             }
         }
-        if ((stat.valid & ZIP_STAT_MTIME) == ZIP_STAT_MTIME)
+        catch (const std::exception& e)
         {
-            const auto sysTime = std::chrono::system_clock::from_time_t(stat.mtime);
-            const auto fileTime = std::chrono::clock_cast<std::chrono::file_clock>(sysTime);
-            std::filesystem::last_write_time(outPath, fileTime);
+            spdlog::error("Failed to materialize zip entry `{}` at `{}`: {}", stat.name, outPath, e.what());
+            return std::unexpected(std::format("Failed to write zip entry to '{}': {}", outPath.string(), e.what()));
         }
     }
     return extractedPath;
@@ -257,6 +265,7 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
             {
                 return std::unexpected(extractedPath.error());
             }
+            try
             {
                 using Disposition = ZipExtractFileDisposition;
                 const auto sourceRoot = std::filesystem::canonical(*extractedPath);
@@ -302,11 +311,18 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
                         continue;
                     }
 
+                    // DeleteIfPresent entries are not copied here (handled in the deletion walk
+                    // below), and must not fall through to last_write_time: the destination may
+                    // never have existed, and stamping a nonexistent path throws filesystem_error.
+                    if (disposition == Disposition::DeleteIfPresent)
+                    {
+                        continue;
+                    }
+
                     switch (disposition)
                     {
                         case Disposition::DeleteIfPresent:
-                            // Handled below when walking deletions
-                            break;
+                            break;  // unreachable, handled above
                         case Disposition::CreateIfAbsent:
                             std::filesystem::copy_file(sourceRoot / relative, destRoot / relative,
                                                        std::filesystem::copy_options::skip_existing);
@@ -344,6 +360,11 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
                 }
 
                 success = true;
+            }
+            catch (const std::exception& e)
+            {
+                spdlog::error("Failed to deploy extracted release contents: {}", e.what());
+                return std::unexpected(std::format("Failed to deploy extracted release: {}", e.what()));
             }
         }
         //

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -31,8 +31,8 @@
     NV_FLAGS_ALLOW_HTTP_DOWNLOAD, used for the HttpRejected negative-control test.
 
 .PARAMETER ArtifactsDir
-    E2E_ARTIFACTS_DIR: directory pre-populated by CI with payload.zip, setup.exe,
-    updater_selfupdate.exe, SignedManifest/, and TamperedManifest/ subdirectories.
+    E2E_ARTIFACTS_DIR: directory pre-populated by CI with payload.zip, payload_edge.zip,
+    setup.exe, updater_selfupdate.exe, SignedManifest/, and TamperedManifest/ subdirectories.
 
 .PARAMETER ServerDir
     Path to the examples/server project directory (for 'dotnet run').
@@ -493,6 +493,18 @@ try {
             Name           = 'HappyZip'
             SourceBin      = $MainBin
             ExeName        = 'e2e_HappyZip_Updater.exe'
+            LocalVersion   = '0.0.1'
+            ExpectedExit   = 203
+            SkipSelfUpdate = $true
+        },
+        @{
+            # Archive-extraction edge cases: empty directory entry, a DeleteIfPresent
+            # override for a file absent at the destination, and a normal create entry.
+            # Regression coverage for crashes/uncaught exceptions previously thrown out
+            # of the setup task by malformed or edge-case ZIP payloads.
+            Name           = 'ZipEdgeCases'
+            SourceBin      = $MainBin
+            ExeName        = 'e2e_ZipEdgeCases_Updater.exe'
             LocalVersion   = '0.0.1'
             ExpectedExit   = 203
             SkipSelfUpdate = $true


### PR DESCRIPTION
## Summary

Part of a runtime-quality remediation series (see the audit for the full findings list). This is PR 1/5 — archive extraction correctness — and is independently mergeable.

- `ExtractReleaseZip()` classified ZIP directory entries by calling `.filename().string().back()` on the *normalised output path*, which can legally be an empty string for entries such as `"dir/"` — calling `.back()` on it is undefined behavior. Directory entries are now classified from the archive's own entry name instead.
- Every per-entry filesystem call in `ExtractReleaseZip()` is now wrapped so a malformed archive returns an `std::expected` failure instead of letting a `std::filesystem_error` unwind out of the background task.
- `ExecuteSetup()`'s deployment walk unconditionally called `last_write_time()` after the disposition `switch`, even for `DeleteIfPresent` entries that are intentionally never copied. When such an entry didn't already exist at the destination (e.g. a first install), stamping mtime on a nonexistent path threw an uncaught `std::filesystem_error`, crashing the process. The walk now skips `DeleteIfPresent` entries entirely, and the whole deployment step is wrapped for exception safety.
- Preserves both pre-existing zip-slip and destination-containment guards.

## Regression coverage

Added a `ZipEdgeCases` E2E scenario (new server endpoint + CI-generated `payload_edge.zip` fixture) exercising, in one release:
- an explicit empty directory entry (`emptydir/`),
- a `DeleteIfPresent` override for a file that is present in the archive but absent at the destination, and
- a normal file extracted with the default `CreateOrReplace` disposition.

Locally verified against both revisions of the code:
- **Pre-fix**: process aborts with exit code `-1073740791` (`0xC0000409`, unhandled C++ exception) when the `DeleteIfPresent` entry is processed.
- **Post-fix**: exits `0xCB` (`203`, `NV_S_UPDATE_FINISHED`); `emptydir/` and `keep.txt` are created, `missing-file.txt` is correctly never written.

## Test plan

- [x] x64 Release solution build succeeds (`vīcĭus.sln`, `Configuration=Release`, `Platform=x64`)
- [x] Manually reproduced the pre-fix crash and confirmed the fix resolves it (see above)
- [ ] CI: Build (x86/x64/ARM64) + E2E Tests workflow runs green, including the new `ZipEdgeCases` scenario


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP extraction handling for empty directories and archive entries.
  * Prevented deployment failures when files marked for conditional deletion are not present.
  * Added clearer error reporting for extraction and deployment failures.
  * Fixed a crash regression involving malformed or edge-case ZIP payloads.

* **Tests**
  * Added end-to-end coverage for ZIP extraction edge cases, including empty directories and missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->