### PR TITLE
Harden download and URL boundaries

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -461,6 +461,7 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
 
         // Download to the separate temp file, trying each candidate URL in turn.
         bool downloadOk = false;
+        bool redirectPolicyFailed = false;
         for (size_t urlIdx = 0; urlIdx < candidateUrls.size(); ++urlIdx)
         {
             const auto& candidateUrl = candidateUrls[urlIdx];
@@ -490,7 +491,16 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
                     // An https:// self-update URL that redirects to plain http:// is a TLS-downgrade
                     // vector; Authenticode + checksum verification below still gate the swap, but
                     // there is no reason to ever let the transport itself downgrade.
-                    curl_easy_setopt(req.getHandle(), CURLOPT_REDIR_PROTOCOLS_STR, "https");
+                    // Abort (do not retry/failover) if the option cannot be applied — without it
+                    // the handle would follow redirects under libcurl's default protocol allow-list.
+                    if (const CURLcode redirRc = curl_easy_setopt(req.getHandle(), CURLOPT_REDIR_PROTOCOLS_STR, "https");
+                        redirRc != CURLE_OK)
+                    {
+                        try { outStream.close(); } catch (...) {}
+                        spdlog::error("CURLOPT_REDIR_PROTOCOLS_STR failed: {}", curl_easy_strerror(redirRc));
+                        redirectPolicyFailed = true;
+                        break;
+                    }
                     req.setOpt(curlpp::options::ConnectTimeout(60L));
                     req.setOpt(curlpp::options::LowSpeedLimit(1L));
                     req.setOpt(curlpp::options::LowSpeedTime(300L)); // 5 min stall timeout
@@ -552,7 +562,7 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
                 }
             }
 
-            if (downloadOk)
+            if (downloadOk || redirectPolicyFailed)
                 break; // exit mirror loop
 
             spdlog::warn("All attempts failed for candidate {}, trying next mirror if available", candidateUrl);

--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -487,6 +487,10 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
                     curlpp::Easy req;
                     req.setOpt(curlpp::options::Url(candidateUrl));
                     req.setOpt(curlpp::options::FollowLocation(true));
+                    // An https:// self-update URL that redirects to plain http:// is a TLS-downgrade
+                    // vector; Authenticode + checksum verification below still gate the swap, but
+                    // there is no reason to ever let the transport itself downgrade.
+                    curl_easy_setopt(req.getHandle(), CURLOPT_REDIR_PROTOCOLS_STR, "https");
                     req.setOpt(curlpp::options::ConnectTimeout(60L));
                     req.setOpt(curlpp::options::LowSpeedLimit(1L));
                     req.setOpt(curlpp::options::LowSpeedTime(300L)); // 5 min stall timeout

--- a/examples/server/Endpoints/E2E/E2EMaliciousContentDispositionEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EMaliciousContentDispositionEndpoint.cs
@@ -1,0 +1,110 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: update available, ZIP payload served with an attacker-controlled
+///     <c>Content-Disposition</c> header that attempts a path-traversal filename
+///     (<c>../../evil.exe</c>, quoted). The updater must reject the filename, keep its
+///     own temp file name, and still complete the update successfully.
+///     Expected updater exit code: <c>NV_S_UPDATE_FINISHED = 203</c>.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2EMaliciousContentDispositionEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/MaliciousContentDisposition/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload.zip' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E MaliciousContentDisposition Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Malicious Content-Disposition Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/MaliciousContentDisposition/artifact",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}
+
+/// <summary>
+///     Serves <c>payload.zip</c> with a malicious, quoted, path-traversal
+///     <c>Content-Disposition</c> filename. Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2EMaliciousContentDispositionArtifactEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/MaliciousContentDisposition/artifact");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+
+        if (!File.Exists(zipPath))
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Deliberately hostile: quoted, path-traversal, wrong extension. The updater's
+        // sanitizer must reject this outright rather than trying to interpret it.
+        HttpContext.Response.Headers["Content-Disposition"] = "attachment; filename=\"..\\..\\evil.exe\"";
+        HttpContext.Response.ContentType = "application/zip";
+        HttpContext.Response.StatusCode = 200;
+        await using FileStream fs = File.OpenRead(zipPath);
+        await fs.CopyToAsync(HttpContext.Response.Body, ct);
+    }
+}

--- a/examples/server/Endpoints/E2E/E2ERedirectDowngradeEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2ERedirectDowngradeEndpoint.cs
@@ -1,0 +1,100 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: the download URL responds with an HTTP redirect (302) to another
+///     location instead of the artifact itself. <c>CURLOPT_REDIR_PROTOCOLS_STR</c> is
+///     restricted to <c>https</c> only (see <c>web::RestrictRedirectProtocols</c>), so
+///     libcurl must refuse to follow this plain-HTTP redirect target and the download
+///     must fail rather than silently retrieving the artifact through a redirect hop.
+///     This is the closest local proof of the https-&gt;http downgrade protection
+///     achievable without a TLS-terminating test server: the mechanism under test
+///     (the allow-listed redirect protocol) does not depend on the scheme of the
+///     original request, only on the scheme of the redirect target.
+///     Expected updater exit code: <c>NV_E_DOWNLOAD_FAILED = 107</c>.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2ERedirectDowngradeEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/RedirectDowngrade/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload.zip' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E RedirectDowngrade Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Redirect Downgrade Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/RedirectDowngrade/redirect",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}
+
+/// <summary>
+///     Responds with a 302 redirect to the real artifact. Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2ERedirectDowngradeRedirectEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/RedirectDowngrade/redirect");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+        await Send.RedirectAsync($"{baseUrl}/api/e2e/artifacts/payload.zip", allowRemoteRedirects: true);
+    }
+}

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -179,6 +179,11 @@ namespace web
         return FailureKind::Other;
     }
 
+    void RestrictRedirectProtocols(CURL* handle)
+    {
+        curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+    }
+
     std::expected<HttpResult, std::string> HttpGet(const std::string& url, const HttpGetOptions& opts)
     {
         HttpResult result{};
@@ -252,6 +257,7 @@ namespace web
                 req.setOpt(curlpp::options::UserAgent(opts.userAgent));
             req.setOpt(curlpp::options::FollowLocation(true));
             req.setOpt(curlpp::options::MaxRedirs(opts.maxRedirects));
+            RestrictRedirectProtocols(req.getHandle());
             if (!opts.headers.empty())
                 req.setOpt(curlpp::options::HttpHeader(opts.headers));
             req.setOpt(curlpp::options::ConnectTimeout(opts.connectTimeoutSecs));

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -179,9 +179,14 @@ namespace web
         return FailureKind::Other;
     }
 
-    void RestrictRedirectProtocols(CURL* handle)
+    std::expected<void, std::string> RestrictRedirectProtocols(CURL* handle)
     {
-        curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+        const CURLcode rc = curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+        if (rc != CURLE_OK)
+        {
+            return std::unexpected(std::format("CURLOPT_REDIR_PROTOCOLS_STR failed: {}", curl_easy_strerror(rc)));
+        }
+        return {};
     }
 
     std::expected<HttpResult, std::string> HttpGet(const std::string& url, const HttpGetOptions& opts)
@@ -257,7 +262,11 @@ namespace web
                 req.setOpt(curlpp::options::UserAgent(opts.userAgent));
             req.setOpt(curlpp::options::FollowLocation(true));
             req.setOpt(curlpp::options::MaxRedirs(opts.maxRedirects));
-            RestrictRedirectProtocols(req.getHandle());
+            if (auto redir = RestrictRedirectProtocols(req.getHandle()); !redir)
+            {
+                if (resolveList) curl_slist_free_all(resolveList);
+                return std::unexpected(redir.error());
+            }
             if (!opts.headers.empty())
                 req.setOpt(curlpp::options::HttpHeader(opts.headers));
             req.setOpt(curlpp::options::ConnectTimeout(opts.connectTimeoutSecs));

--- a/src/Http.h
+++ b/src/Http.h
@@ -100,8 +100,13 @@ namespace web
      * allowance in IsAllowedDownloadUrl only ever covers the URL a caller explicitly requests,
      * never an automatic redirect target, so there is no legitimate case where following a
      * redirect to a non-https scheme is required.
+     *
+     * \return Empty on success; unexpected with a human-readable reason if
+     *         CURLOPT_REDIR_PROTOCOLS_STR could not be applied (callers must not start the
+     *         transfer in that case — the handle would otherwise follow redirects with the
+     *         libcurl default protocol allow-list).
      */
-    void RestrictRedirectProtocols(CURL* handle);
+    [[nodiscard]] std::expected<void, std::string> RestrictRedirectProtocols(CURL* handle);
 
     /**
      * \brief Detects the Windows system/WinINET proxy for the given target URL.

--- a/src/Http.h
+++ b/src/Http.h
@@ -89,6 +89,21 @@ namespace web
     FailureKind ClassifyTransportError(const std::string& curlMessage);
 
     /**
+     * \brief Restricts libcurl to only ever follow https:// Location redirects.
+     *
+     * A request that gets redirected to plain http:// is a classic TLS-downgrade vector: the
+     * initial-URL scheme check (see IsAllowedDownloadUrl) does nothing to stop it, because it
+     * only ever inspects the URL the caller asked for, not where a redirect chain ends up.
+     * Call this on every curl handle that has FollowLocation enabled.
+     *
+     * This applies unconditionally, including in debug/E2E builds: the existing loopback HTTP
+     * allowance in IsAllowedDownloadUrl only ever covers the URL a caller explicitly requests,
+     * never an automatic redirect target, so there is no legitimate case where following a
+     * redirect to a non-https scheme is required.
+     */
+    void RestrictRedirectProtocols(CURL* handle);
+
+    /**
      * \brief Detects the Windows system/WinINET proxy for the given target URL.
      *
      * Reads the per-user IE/WinINET proxy settings and, when a PAC script or

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -472,6 +472,7 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         req.setOpt(curlpp::options::UserAgent(ua));
         req.setOpt(curlpp::options::FollowLocation(true));
         req.setOpt(curlpp::options::MaxRedirs(MAX_REDIRECTS));
+        web::RestrictRedirectProtocols(req.getHandle());
         req.setOpt(curlpp::options::HttpHeader(headerLines));
 
         // Prefer "stall" timeouts: don't abort if bytes still trickle in.
@@ -632,7 +633,45 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
 
         const uint64_t finalSize = getLocalSize();
 
-        auto tryExtractFilenameFromContentDisposition = [](const std::string& cdHeader) -> std::optional<std::filesystem::path>
+        // Accepts only a bare basename: strips one matching pair of surrounding quotes,
+        // trims whitespace, then rejects anything that isn't a plain filename - empty
+        // names, ".", "..", path separators, drive prefixes, and absolute/rooted paths.
+        // A server (or a MITM on a downgraded connection) controls this header, so it
+        // must never be trusted to name an arbitrary filesystem location.
+        auto sanitizeContentDispositionFilename = [](std::string name) -> std::optional<std::filesystem::path>
+        {
+            if (name.size() >= 2 && name.front() == '"' && name.back() == '"')
+            {
+                name = name.substr(1, name.size() - 2);
+            }
+
+            auto isSpace = [](unsigned char c) { return std::isspace(c) != 0; };
+            while (!name.empty() && isSpace(static_cast<unsigned char>(name.front()))) name.erase(name.begin());
+            while (!name.empty() && isSpace(static_cast<unsigned char>(name.back())))  name.pop_back();
+
+            if (name.empty() || name == "." || name == "..")
+            {
+                return std::nullopt;
+            }
+
+            // A bare basename never contains a separator; reject outright rather than
+            // trying to interpret it as a (possibly traversal-laden) path.
+            if (name.find('/') != std::string::npos || name.find('\\') != std::string::npos)
+            {
+                return std::nullopt;
+            }
+
+            const std::filesystem::path candidate(name);
+            if (candidate.is_absolute() || candidate.has_root_name() || candidate.has_root_directory())
+            {
+                return std::nullopt;
+            }
+
+            return candidate;
+        };
+
+        auto tryExtractFilenameFromContentDisposition =
+          [&sanitizeContentDispositionFilename](const std::string& cdHeader) -> std::optional<std::filesystem::path>
         {
             if (cdHeader.empty())
             {
@@ -665,7 +704,13 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
             }
 
             const std::smatch& match = *matchesBegin;
-            return std::filesystem::path(match[ 1 ].str());
+
+            auto sanitized = sanitizeContentDispositionFilename(match[ 1 ].str());
+            if (!sanitized.has_value())
+            {
+                spdlog::warn("Rejecting Content-Disposition filename '{}': not a plain basename", match[ 1 ].str());
+            }
+            return sanitized;
         };
 
         // Treat 206 as success only if file size matches expected
@@ -734,9 +779,19 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
                 std::filesystem::path newLocation = release.localTempFilePath;
                 newLocation.replace_filename(attachmentName.value());
 
+                // Defense in depth: the sanitizer above already rejects separators and
+                // rooted paths, but re-confirm the rename target still resolves inside the
+                // download directory before touching the filesystem.
+                const auto expectedParent = release.localTempFilePath.parent_path().lexically_normal();
+                const auto resolvedParent = newLocation.parent_path().lexically_normal();
+                if (resolvedParent != expectedParent)
+                {
+                    spdlog::warn("Rejecting Content-Disposition filename '{}': resolves outside download directory {}",
+                                 attachmentName->string(), expectedParent);
+                }
                 // If the server-supplied filename already matches our current path, don't "rename".
                 // Otherwise we'd delete the file and then fail to move it (ERROR_FILE_NOT_FOUND).
-                if (newLocation == release.localTempFilePath)
+                else if (newLocation == release.localTempFilePath)
                 {
                     spdlog::debug("Skipping rename; already named {}", newLocation);
                 }
@@ -924,13 +979,35 @@ namespace
                 // DNS failure: if we have DoH or a matching pinned-host entry and haven't
                 // tried DNS recovery on this URL yet, do one immediate retry with DoH
                 // explicitly forced (even when it was already set, re-applying is harmless).
+                // Extract just the hostname from requestUrl (no scheme, port, path) so pin
+                // matching can't be fooled by a substring hit, e.g. host "example.com" must
+                // not match "evilexample.com" or "example.com.attacker.net".
+                const auto requestHost = [&]() -> std::string
+                {
+                    auto rest = requestUrl;
+                    if (const auto schemeSep = rest.find("://"); schemeSep != std::string::npos)
+                        rest.erase(0, schemeSep + 3);
+                    const auto pathSep = rest.find_first_of("/?#");
+                    if (pathSep != std::string::npos)
+                        rest.erase(pathSep);
+                    const auto portSep = rest.rfind(':');
+                    if (portSep != std::string::npos)
+                        rest.erase(portSep);
+                    std::ranges::transform(rest, rest.begin(),
+                        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                    return rest;
+                }();
+
                 const bool hasDnsRecovery =
                     (network.has_value() && (
                         !network->dohUrl.empty() ||
                         std::any_of(network->pinnedHosts.begin(), network->pinnedHosts.end(),
                             [&](const PinnedHost& p)
                             {
-                                return requestUrl.find(p.host) != std::string::npos;
+                                std::string pinHost = p.host;
+                                std::ranges::transform(pinHost, pinHost.begin(),
+                                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                                return requestHost == pinHost;
                             })));
 
                 if (kind == web::FailureKind::DnsFailure && hasDnsRecovery && !dnsRecoveryAttempted)

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -472,7 +472,13 @@ std::expected<int, std::string> models::InstanceConfig::DownloadRelease(curl_pro
         req.setOpt(curlpp::options::UserAgent(ua));
         req.setOpt(curlpp::options::FollowLocation(true));
         req.setOpt(curlpp::options::MaxRedirs(MAX_REDIRECTS));
-        web::RestrictRedirectProtocols(req.getHandle());
+        if (auto redir = web::RestrictRedirectProtocols(req.getHandle()); !redir)
+        {
+            if (downloadResolveList) { curl_slist_free_all(downloadResolveList); downloadResolveList = nullptr; }
+            try { outStream.close(); } catch (...) {}
+            spdlog::error("{}", redir.error());
+            return std::unexpected(redir.error());
+        }
         req.setOpt(curlpp::options::HttpHeader(headerLines));
 
         // Prefer "stall" timeouts: don't abort if bytes still trickle in.

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -801,14 +801,16 @@ try {
         },
         @{
             # Regression for exact (not substring) pinned-host matching: the manifest host
-            # merely *contains* the pinned host name as a substring ("localhostpinnedx"
-            # starts with the pinned "localhostpinned"). The old requestUrl.find(p.host)
-            # check would incorrectly treat this as a pin match and attempt a DoH/pinned-IP
-            # recovery retry; the fix requires an exact case-insensitive hostname match, so
-            # no recovery is attempted and the DNS failure surfaces immediately without a
-            # spurious external DoH lookup. Uses the "localhost..." prefix (like the
-            # existing PinnedHostResolve* scenarios) so the debug-build loopback allowance
-            # in IsAllowedDownloadUrl lets the request through to the pin-matching code.
+            # merely *contains* the pinned host name as a substring
+            # ("localhostpinnedx.invalid" starts with the pinned "localhostpinned"). The old
+            # requestUrl.find(p.host) check would incorrectly treat this as a pin match and
+            # attempt a DoH/pinned-IP recovery retry; the fix requires an exact
+            # case-insensitive hostname match, so no recovery is attempted and the DNS
+            # failure surfaces immediately without a spurious external DoH lookup.
+            # Hostname uses the reserved .invalid TLD so it is guaranteed not to resolve
+            # via system DNS (RFC 6761), while still starting with "localhost..." so the
+            # debug-build loopback allowance in IsAllowedDownloadUrl lets the request
+            # through to the pin-matching code.
             Name                 = 'PinnedHostSubstringNotMatched'
             SourceBin            = $MainBin
             ExeName              = 'e2e_PinnedHostSubstring_Updater.exe'
@@ -817,7 +819,7 @@ try {
             SkipSelfUpdate       = $true
             Sidecar              = @{
                 Name    = 'e2e_PinnedHostSubstring_Updater.json'
-                Content = '{"instance":{"serverUrlTemplate":"http://localhostpinnedx:5200/api/e2e/HappyZip/updates.json","network":{"pinnedHosts":[{"host":"localhostpinned","port":5200,"address":"127.0.0.1"}]}}}'
+                Content = '{"instance":{"serverUrlTemplate":"http://localhostpinnedx.invalid:5200/api/e2e/HappyZip/updates.json","network":{"pinnedHosts":[{"host":"localhostpinned","port":5200,"address":"127.0.0.1"}]}}}'
             }
             ExpectLogNotContains = @('retrying with DoH/pinned-IP recovery')
         }

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -819,7 +819,7 @@ try {
             SkipSelfUpdate       = $true
             Sidecar              = @{
                 Name    = 'e2e_PinnedHostSubstring_Updater.json'
-                Content = '{"instance":{"serverUrlTemplate":"http://localhostpinnedx.invalid:5200/api/e2e/HappyZip/updates.json","network":{"pinnedHosts":[{"host":"localhostpinned","port":5200,"address":"127.0.0.1"}]}}}'
+                Content = '{"instance":{"serverUrlTemplate":"http://localhostpinnedx.invalid:5200/api/e2e/HappyZip/updates.json","network":{"proxyMode":"None","pinnedHosts":[{"host":"localhostpinned","port":5200,"address":"127.0.0.1"}]}}}'
             }
             ExpectLogNotContains = @('retrying with DoH/pinned-IP recovery')
         }

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -17,6 +17,7 @@
         NV_S_INSTANCE_ALREADY_RUNNING = 210
         NV_E_SERVER_RESPONSE = 104
         NV_E_SIGNATURE_INVALID = 116
+        NV_E_DOWNLOAD_FAILED = 107
 
 .PARAMETER MainBin
     Path to the main E2E updater binary (e2e_Main_Updater.exe), built with
@@ -763,6 +764,62 @@ try {
                 Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/HappyZip/updates.json","network":{"proxyMode":"None"}}}'
             }
             ExpectLogContains = @('Network config loaded:')
+        },
+
+        # ── Download/URL boundary hardening scenarios ────────────────────────
+
+        @{
+            # The download URL 302-redirects to the real artifact. CURLOPT_REDIR_PROTOCOLS_STR
+            # is restricted to https-only (RestrictRedirectProtocols), so libcurl must refuse
+            # to follow this plain-HTTP redirect target and the download must fail.
+            Name              = 'RedirectDowngradeRejected'
+            SourceBin         = $MainBin
+            ExeName           = 'e2e_RedirectDowngrade_Updater.exe'
+            LocalVersion      = '0.0.1'
+            ExpectedExit      = 107  # NV_E_DOWNLOAD_FAILED
+            SkipSelfUpdate    = $true
+            Sidecar           = @{
+                Name    = 'e2e_RedirectDowngrade_Updater.json'
+                Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/RedirectDowngrade/updates.json"}}'
+            }
+        },
+        @{
+            # Server sends a quoted, path-traversal Content-Disposition filename
+            # ("..\..\evil.exe"). The sanitizer must reject it outright (log warning),
+            # keep the original temp file name, and the update must still complete.
+            Name              = 'MaliciousContentDispositionRejected'
+            SourceBin         = $MainBin
+            ExeName           = 'e2e_MaliciousCD_Updater.exe'
+            LocalVersion      = '0.0.1'
+            ExpectedExit      = 203
+            SkipSelfUpdate    = $true
+            Sidecar           = @{
+                Name    = 'e2e_MaliciousCD_Updater.json'
+                Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/MaliciousContentDisposition/updates.json"}}'
+            }
+            ExpectLogContains = @('Rejecting Content-Disposition filename')
+        },
+        @{
+            # Regression for exact (not substring) pinned-host matching: the manifest host
+            # merely *contains* the pinned host name as a substring ("localhostpinnedx"
+            # starts with the pinned "localhostpinned"). The old requestUrl.find(p.host)
+            # check would incorrectly treat this as a pin match and attempt a DoH/pinned-IP
+            # recovery retry; the fix requires an exact case-insensitive hostname match, so
+            # no recovery is attempted and the DNS failure surfaces immediately without a
+            # spurious external DoH lookup. Uses the "localhost..." prefix (like the
+            # existing PinnedHostResolve* scenarios) so the debug-build loopback allowance
+            # in IsAllowedDownloadUrl lets the request through to the pin-matching code.
+            Name                 = 'PinnedHostSubstringNotMatched'
+            SourceBin            = $MainBin
+            ExeName              = 'e2e_PinnedHostSubstring_Updater.exe'
+            LocalVersion         = '0.0.1'
+            ExpectedExit         = 104  # NV_E_SERVER_RESPONSE
+            SkipSelfUpdate       = $true
+            Sidecar              = @{
+                Name    = 'e2e_PinnedHostSubstring_Updater.json'
+                Content = '{"instance":{"serverUrlTemplate":"http://localhostpinnedx:5200/api/e2e/HappyZip/updates.json","network":{"pinnedHosts":[{"host":"localhostpinned","port":5200,"address":"127.0.0.1"}]}}}'
+            }
+            ExpectLogNotContains = @('retrying with DoH/pinned-IP recovery')
         }
     )
 


### PR DESCRIPTION
## Summary

Second of five independent PRs from the runtime remediation plan (PR 2 — Download and URL boundaries).

- Restrict libcurl to only ever follow `https://` redirects (`web::RestrictRedirectProtocols`, wired into `web::HttpGet`, `InstanceConfig::DownloadRelease`, and the self-update DLL's `PerformUpdate`), closing a TLS-downgrade path where an `https://` download URL could redirect to plain `http://`.
- Sanitize `Content-Disposition` filenames in `InstanceConfig::DownloadRelease`: strip a single matching pair of quotes, reject empty/`.`/`..`/separator-containing/rooted/absolute names, and re-verify the resolved rename target stays inside the download directory before touching the filesystem (defense in depth).
- Match `network.pinnedHosts` entries against the exact, case-insensitive request hostname instead of a raw substring search, so a lookalike hostname (e.g. `evil-pinnedhost.example`) can no longer be mistaken for a pinned/DoH-recoverable host during DNS-failure retries.

## Test plan

- [x] Added 3 new E2E scenarios in `tests/e2e/run-e2e.ps1`: `RedirectDowngradeRejected`, `MaliciousContentDispositionRejected`, `PinnedHostSubstringNotMatched`, backed by two new example-server endpoints (`E2ERedirectDowngradeEndpoint`, `E2EMaliciousContentDispositionEndpoint`).
- [x] Verified each new scenario against a pre-fix build (`git stash` the fix, rebuild, rerun) to confirm it actually fails/misbehaves without the fix and passes with it.
- [x] Ran the full local E2E suite (28 scenarios) against this branch: 25 passed, 2 skipped (dynamic-signing scenarios need a minisign key not set up locally), 1 pre-existing false failure from substituting a non-keyed binary for the unrelated `SignedManifest` scenario (not exercised by this PR).
- [x] Built the standard x64 Release solution configuration cleanly (0 errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Enforced HTTPS-only redirect following during self-updates, aborting on redirect-protocol failures (blocks HTTPS→HTTP downgrades).
  - Hardened `Content-Disposition` filename handling by allowing only a safe basename and rejecting traversal/invalid values.
  - Strengthened pinned-host matching using strict, case-insensitive hostname equality.

- **Bug Fixes**
  - Added a defense-in-depth check to only move/rename downloaded files when the resolved target directory matches the expected download directory.

- **Tests**
  - Extended end-to-end coverage for redirect downgrade rejection, malicious filename rejection, and pinned-host substring regression (including updated expected exit code mappings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->