### PR TITLE
Fix async shutdown races and make task ownership deterministic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,6 +505,29 @@ jobs:
           path: e2e-logs/**
           if-no-files-found: ignore
 
+      # ── Async-shutdown lifecycle tests ──────────────────────────────────────
+      # Unlike run-e2e.ps1 (headless --silent-update only), this drives the interactive
+      # window via NV_E2E_AUTO_ADVANCE and posts WM_CLOSE while a background task is
+      # genuinely in flight, exercising the WM_QUIT stop_source wiring and
+      # markdown::Shutdown() added for async task lifecycle safety.
+
+      - name: Run async-shutdown lifecycle E2E tests
+        shell: pwsh
+        run: |
+          pwsh tests\e2e\run-lifecycle-e2e.ps1 `
+            -MainBin      "bin\x64\e2e_Main_Updater.exe" `
+            -ArtifactsDir "$env:E2E_ARTIFACTS_DIR" `
+            -ServerDir    "examples\server" `
+            -LogDir       "e2e-lifecycle-logs"
+
+      - name: Upload lifecycle E2E logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: e2e-lifecycle-logs
+          path: e2e-lifecycle-logs/**
+          if-no-files-found: ignore
+
   # ─── Release ───────────────────────────────────────────────────────────────
   release:
     name: Publish GitHub Release

--- a/examples/e2e-setup-stub/Program.cs
+++ b/examples/e2e-setup-stub/Program.cs
@@ -6,6 +6,15 @@
 //
 // The exit code can be overridden for negative-test variants by setting the
 // E2E_EXIT_CODE environment variable before launching the updater.
+//
+// E2E_EXIT_DELAY_MS optionally sleeps before exiting, used by the async-shutdown
+// lifecycle tests to keep "setup is running" true long enough for the harness to
+// close the updater window mid-install (CreateProcess inherits the parent's
+// environment by default, so setting this on the updater process before launch
+// propagates to this child).
+int delayMs = int.TryParse(Environment.GetEnvironmentVariable("E2E_EXIT_DELAY_MS"), out int d) ? d : 0;
+if (delayMs > 0)
+    Thread.Sleep(delayMs);
 
 int exitCode = int.TryParse(Environment.GetEnvironmentVariable("E2E_EXIT_CODE"), out int c) ? c : 0;
 Environment.Exit(exitCode);

--- a/examples/server/Endpoints/E2E/E2EArtifactEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EArtifactEndpoint.cs
@@ -52,6 +52,13 @@ internal sealed class E2EArtifactEndpoint : Endpoint<E2EArtifactRequest>
 
         HttpContext.Response.ContentType = contentType;
         HttpContext.Response.StatusCode = 200;
+
+        // Async-shutdown lifecycle tests: an optional artificial delay before any bytes
+        // are written keeps the updater's download task genuinely in flight, giving the
+        // harness a wide, deterministic window to close the app mid-download.
+        if (req.DelayMs > 0)
+            await Task.Delay(req.DelayMs, ct);
+
         await using FileStream fs = File.OpenRead(filePath);
         await fs.CopyToAsync(HttpContext.Response.Body, ct);
     }
@@ -60,4 +67,5 @@ internal sealed class E2EArtifactEndpoint : Endpoint<E2EArtifactRequest>
 internal sealed class E2EArtifactRequest
 {
     public string Name { get; set; } = string.Empty;
+    public int DelayMs { get; set; }
 }

--- a/examples/server/Endpoints/E2E/E2ELifecycleEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2ELifecycleEndpoint.cs
@@ -1,0 +1,81 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario for async-shutdown lifecycle testing: both the changelog image
+///     referenced from the release summary and the release artifact itself are served
+///     through an artificial delay, so the harness has a wide, deterministic window to
+///     close the updater window while the image-download task and/or the release-download
+///     task are genuinely still in flight (see markdown::Shutdown and
+///     InstanceConfig::WaitForDownloadToFinish).
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2ELifecycleEndpoint : EndpointWithoutRequest
+{
+    // Comfortably longer than the harness waits before sending WM_CLOSE, so the tasks are
+    // still running at close time, and comfortably shorter than the harness's bounded exit
+    // timeout would be if the wait were naively for the full delay (it must not be, after
+    // the fix: the process should exit long before this elapses).
+    private const int DelayMs = 8000;
+
+    public override void Configure()
+    {
+        Get("api/e2e/Lifecycle/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload.zip' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+        // Reuses payload.zip bytes as a stand-in "image": the client's WIC decode will fail
+        // once the delayed response eventually arrives, but that happens long after the
+        // harness has already closed the window, so decode success is irrelevant here.
+        string delayedArtifactUrl = $"{baseUrl}/api/e2e/artifacts/payload.zip?delayMs={DelayMs}";
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E Lifecycle Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Lifecycle Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = $"![delayed]({delayedArtifactUrl})",
+                    DownloadUrl = delayedArtifactUrl,
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/examples/server/Endpoints/E2E/E2ELifecycleSetupEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2ELifecycleSetupEndpoint.cs
@@ -1,0 +1,77 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario for async-shutdown lifecycle testing: a normal, fast download/verify
+///     followed by a setup.exe that is deliberately kept "running" for a while (via the
+///     E2E_EXIT_DELAY_MS environment variable inherited by the child process; see
+///     examples/e2e-setup-stub/Program.cs). This gives the harness a wide, deterministic
+///     window to close the updater window while InstanceConfig::setupTask is genuinely in
+///     flight, so it can verify closing is bounded by the cooperative stop_source
+///     (see main.cpp's WM_QUIT handling and InstanceConfig::WaitForSetupToFinish) rather
+///     than by the full setup process duration.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2ELifecycleSetupEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/LifecycleSetup/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string exePath = Path.Combine(artifactsDir, "setup.exe");
+        if (!File.Exists(exePath))
+            ThrowError("E2E fixture 'setup.exe' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(exePath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E LifecycleSetup Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Lifecycle Setup Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/artifacts/setup.exe",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    },
+                    ExitCode = new ExitCodeCheck
+                    {
+                        SuccessCodes = { 0 }
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/src/InstanceConfig.Download.cpp
+++ b/src/InstanceConfig.Download.cpp
@@ -31,7 +31,21 @@ bool models::InstanceConfig::DownloadReleaseAsync(int releaseIndex, curl_progres
 
     if (status.hasFinished)
     {
-        status.result = downloadTask->get();
+        // DownloadRelease reports failures via std::expected; guard against any exception
+        // that escaped it anyway so a polling call on the render thread can never propagate
+        // one out (that would unwind through the ImGui/DirectX frame and crash the app).
+        try
+        {
+            status.result = downloadTask->get();
+        }
+        catch (const std::exception& e)
+        {
+            status.result = std::unexpected(std::format("Download task failed with an exception: {}", e.what()));
+        }
+        catch (...)
+        {
+            status.result = std::unexpected("Download task failed with an unknown exception");
+        }
     }
 
     return status;

--- a/src/InstanceConfig.Security.cpp
+++ b/src/InstanceConfig.Security.cpp
@@ -220,7 +220,24 @@ std::optional<models::InstanceConfig::VerifyStatus> models::InstanceConfig::GetV
     status.hasFinished = futureStatus == std::future_status::ready;
 
     if (status.hasFinished)
-        status.result = verifyTask->get();
+    {
+        // VerifyReleaseIntegrity reports failures via std::expected; guard against any
+        // exception that escaped it anyway so a polling call on the render thread can never
+        // propagate one out (that would unwind through the ImGui/DirectX frame and crash
+        // the app).
+        try
+        {
+            status.result = verifyTask->get();
+        }
+        catch (const std::exception& e)
+        {
+            status.result = std::unexpected(std::format("Verification task failed with an exception: {}", e.what()));
+        }
+        catch (...)
+        {
+            status.result = std::unexpected("Verification task failed with an unknown exception");
+        }
+    }
 
     return status;
 }
@@ -237,6 +254,14 @@ void models::InstanceConfig::ResetVerifyState()
         verifyTask.reset();
     // Still running: leave it.  VerifyReleaseIntegrityAsync guards against re-launch,
     // and GetVerifyStatus will eventually report completion on a later frame.
+}
+
+void models::InstanceConfig::WaitForVerifyToFinish()
+{
+    if (!verifyTask.has_value())
+        return;
+
+    verifyTask->wait();
 }
 
 // ============================================================================

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -81,7 +81,31 @@ bool models::InstanceConfig::InvokeSetupAsync(const std::stop_token& stopToken)
     return true;
 }
 
-void models::InstanceConfig::ResetSetupState() { setupTask.reset(); }
+void models::InstanceConfig::ResetSetupState()
+{
+    if (!setupTask.has_value())
+    {
+        return;
+    }
+
+    // Only drop the shared_future if the task has already completed; dropping a not-yet-ready
+    // shared_future created via std::async blocks the calling thread (the render thread) until
+    // the background setup finishes (mirrors ResetVerifyState). Still running: leave it in
+    // place. GetSetupStatus will report completion on a later frame; WaitForSetupToFinish
+    // provides a bounded, explicit blocking wait for callers that actually need to end it now.
+    if (setupTask->wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+        setupTask.reset();
+}
+
+void models::InstanceConfig::WaitForSetupToFinish()
+{
+    if (!setupTask.has_value())
+    {
+        return;
+    }
+
+    setupTask->wait();
+}
 
 std::optional<models::InstanceConfig::SetupStatus> models::InstanceConfig::GetSetupStatus() const
 {
@@ -98,7 +122,21 @@ std::optional<models::InstanceConfig::SetupStatus> models::InstanceConfig::GetSe
 
     if (status.hasFinished)
     {
-        status.result = (*setupTask).get();
+        // ExecuteSetup reports failures via std::expected; guard against any exception that
+        // escaped it anyway so a polling call on the render thread can never propagate one
+        // out (that would unwind through the ImGui/DirectX frame and crash the app).
+        try
+        {
+            status.result = (*setupTask).get();
+        }
+        catch (const std::exception& e)
+        {
+            status.result = std::unexpected(std::format("Setup task failed with an exception: {}", e.what()));
+        }
+        catch (...)
+        {
+            status.result = std::unexpected("Setup task failed with an unknown exception");
+        }
     }
 
     return status;

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -557,6 +557,13 @@ models::InstanceConfig::~InstanceConfig()
     RequestAbortDownload();
     WaitForDownloadToFinish();
 
+    // Defense in depth: member tasks capture `this` via std::async, so this object must
+    // never be destroyed while one is still running. The normal shutdown path (main.cpp)
+    // already requests a stop and waits before destroying `cfg`, so these are typically
+    // no-ops by the time we get here; they remain a backstop for any other exit path.
+    WaitForSetupToFinish();
+    WaitForVerifyToFinish();
+
     // clean up release resources
     for (const auto& release : remote.releases)
     {

--- a/src/UI.h
+++ b/src/UI.h
@@ -4,6 +4,18 @@
 namespace markdown
 {
     void RenderChangelog(const std::string& markdown);
+
+    /**
+     * \brief Stops accepting new changelog image downloads and blocks until any in-flight
+     *        download finishes.
+     *
+     * Must be called before curlpp::terminate() and D3D device teardown: the changelog
+     * renderer keeps its image-download tasks in a function-local static object that
+     * outlives main(), so without this, a background download could still be running
+     * DownloadImageTexture() (which calls into libcurl and CreateWICTextureFromMemory)
+     * after those globals are gone.
+     */
+    void Shutdown();
 }
 
 namespace ui

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 
 #include <curlpp/cURLpp.hpp>
 
+#include <cstdlib>
+
 
 //
 // Enable visual styles
@@ -709,6 +711,23 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     std::once_flag errorUrlTriggered;
     std::stop_source stopSource;
 
+#if defined(NV_FLAGS_ALLOW_HTTP_DOWNLOAD)
+    // E2E-only: lets the lifecycle test harness (tests/e2e) drive the wizard to the
+    // download/verify/install steps without simulating mouse clicks against an ImGui
+    // window (which has no OS accessibility tree), so it can send WM_CLOSE while a
+    // download/verify/setup/image-fetch task is genuinely in flight. Compiled only into
+    // E2E test binaries -- NV_FLAGS_ALLOW_HTTP_DOWNLOAD is never defined for production
+    // builds -- and still requires an explicit opt-in env var so no existing E2E scenario
+    // changes behavior.
+    const bool e2eAutoAdvanceWizard = [] {
+        char* value = nullptr;
+        size_t len = 0;
+        const bool isSet = _dupenv_s(&value, &len, "NV_E2E_AUTO_ADVANCE") == 0 && value != nullptr;
+        free(value);
+        return isSet;
+    }();
+#endif
+
     // Main loop
     bool done = false;
     while (!done)
@@ -725,8 +744,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
         }
         if (done)
         {
+            // Cooperatively cancel any in-progress setup (ExecuteSetup observes this token,
+            // e.g. via CancellableWait on the launched installer process) before waiting for
+            // it, so closing the window can never hang on an installer that would otherwise
+            // run to completion on its own schedule.
+            stopSource.request_stop();
+
             cfg.RequestAbortDownload();
             cfg.WaitForDownloadToFinish();
+            cfg.WaitForSetupToFinish();
+            cfg.WaitForVerifyToFinish();
             break;
         }
 
@@ -818,7 +845,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                 ImGui::PushStyleColor(ImGuiCol_Button,        winapi::GetAccentColor());
                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, winapi::GetAccentColorHovered());
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive,  winapi::GetAccentColorActive());
-                if (ImGui::Button(ICON_FK_DOWNLOAD " Display update details now"))
+                bool displayDetailsClicked = ImGui::Button(ICON_FK_DOWNLOAD " Display update details now");
+#if defined(NV_FLAGS_ALLOW_HTTP_DOWNLOAD)
+                displayDetailsClicked = displayDetailsClicked || e2eAutoAdvanceWizard;
+#endif
+                if (displayDetailsClicked)
                 {
                     currentPage = cfg.HasSingleRelease()
                                       ? WizardPage::SingleVersionSummary
@@ -899,7 +930,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                 ImGui::PushStyleColor(ImGuiCol_Button,        winapi::GetAccentColor());
                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, winapi::GetAccentColorHovered());
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive,  winapi::GetAccentColorActive());
-                if (ImGui::Button("Download and install"))
+                bool downloadClicked = ImGui::Button("Download and install");
+#if defined(NV_FLAGS_ALLOW_HTTP_DOWNLOAD)
+                downloadClicked = downloadClicked || e2eAutoAdvanceWizard;
+#endif
+                if (downloadClicked)
                 {
                     instStep = DownloadAndInstallStep::Begin;
                     currentPage = WizardPage::DownloadAndInstall;
@@ -1375,6 +1410,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
         //HRESULT hr = g_pSwapChain->Present(0, 0); // Present without vsync
         g_SwapChainOccluded = (hr == DXGI_STATUS_OCCLUDED);
     }
+
+    // Stop accepting new changelog image downloads and wait for any in-flight one to
+    // finish; it captures g_pd3dDevice and runs curl calls on a background task (see
+    // markdown::Shutdown), so this must happen before the D3D/curlpp teardown below.
+    markdown::Shutdown();
 
     // Cleanup
     ImGui_ImplDX11_Shutdown();

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -50,6 +50,9 @@ struct changelog : imgui_md
     std::string m_img_href;
     std::regex m_regex_link_target;
     std::map<std::string /* URL */, OptionalSharedFutureD3DResource /* Texture downloader */> imageDownloadTasks;
+    // Set once by Shutdown(); checked before starting any new download so no task is ever
+    // launched after the caller has started tearing down libcurl/D3D.
+    std::atomic_bool shuttingDown{false};
 
     explicit changelog(const D3DResourceMap& images)
         : _images(images)
@@ -217,6 +220,11 @@ struct changelog : imgui_md
         // this gets called on every frame so we only download it once and cache it
         if (!_images.contains(url))
         {
+            if (shuttingDown.load(std::memory_order_acquire))
+            {
+                return std::nullopt;
+            }
+
             // no download task is assigned to the given url, initiate
             if (!imageDownloadTasks.contains(url) || !imageDownloadTasks[ url ].has_value())
             {
@@ -290,6 +298,27 @@ struct changelog : imgui_md
     }
 
     /**
+     * \brief Stops accepting new downloads and blocks until any in-flight ones finish.
+     *        Safe to call multiple times; safe to call even if nothing was ever downloaded.
+     */
+    void Shutdown()
+    {
+        shuttingDown.store(true, std::memory_order_release);
+
+        // wait() never rethrows a stored exception (only get() does), so this is safe even
+        // if DownloadImageTexture's WIC/curl call chain ever starts throwing.
+        for (auto& entry : imageDownloadTasks)
+        {
+            if (entry.second.has_value())
+            {
+                entry.second->wait();
+            }
+        }
+
+        imageDownloadTasks.clear();
+    }
+
+    /**
      * \brief Pulls the texture for the requested image to render.
      * \param nfo Image info to fill out.
      * \return True on success, false otherwise.
@@ -314,13 +343,27 @@ struct changelog : imgui_md
     }
 };
 
+namespace
+{
+    // Function-local static: outlives main(), which is exactly why its image-download
+    // tasks need an explicit Shutdown() call before curlpp/D3D teardown (see markdown::Shutdown).
+    changelog& GetChangelogInstance()
+    {
+        static changelog cl_render(G_ImageTextures);
+        return cl_render;
+    }
+}
+
 /**
  * \brief Parses a provided Markdown body string and renders it onto an ImGui widget.
  * \param markdown The Markdown document body.
  */
 void markdown::RenderChangelog(const std::string& markdown)
 {
-    static changelog cl_render(G_ImageTextures);
+    GetChangelogInstance().print(markdown.c_str(), markdown.c_str() + markdown.length());
+}
 
-    cl_render.print(markdown.c_str(), markdown.c_str() + markdown.length());
+void markdown::Shutdown()
+{
+    GetChangelogInstance().Shutdown();
 }

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -318,6 +318,9 @@ namespace models
         /**
          * \brief Checks the current download status.
          * \return nullopt if no download was invoked; otherwise a DownloadStatus snapshot.
+         * \remarks Any exception escaping DownloadRelease is caught and reported as a
+         *          human-readable failure in the returned result rather than propagating
+         *          out of this polling call.
          */
         [[nodiscard]] std::optional<DownloadStatus> GetReleaseDownloadStatus() const;
 
@@ -582,6 +585,15 @@ namespace models
 
         bool InvokeSetupAsync(const std::stop_token&);
 
+        /**
+         * \brief Discards the completed setup task.
+         *
+         * Nonblocking guard, matching ResetVerifyState(): dropping the last reference to a
+         * not-yet-ready shared_future created via std::async blocks the calling thread (the
+         * render thread) until the background setup finishes. If the task is still running,
+         * this is a no-op; call WaitForSetupToFinish() first (e.g. after requesting a stop)
+         * when the task truly needs to end.
+         */
         void ResetSetupState();
 
         /** Returned by GetSetupStatus when a setup task has been invoked. */
@@ -593,8 +605,19 @@ namespace models
         };
 
         /** \brief Polls the in-progress setup task.
-         *  \return nullopt if no task was started; otherwise a SetupStatus snapshot. */
+         *  \return nullopt if no task was started; otherwise a SetupStatus snapshot.
+         *  \remarks Any exception escaping ExecuteSetup is caught and reported as a
+         *           human-readable failure in the returned result rather than propagating
+         *           out of this polling call. */
         [[nodiscard]] std::optional<SetupStatus> GetSetupStatus() const;
+
+        /**
+         * \brief Blocks until the running setup task (if any) finishes.
+         * \remarks Call stop_source::request_stop() on the token passed to InvokeSetupAsync
+         *          first so the wait is bounded; ExecuteSetup observes it at safe points
+         *          (e.g. CancellableWait on the launched installer process).
+         */
+        void WaitForSetupToFinish();
 
         bool TryRunTemporaryProcess() const;
 
@@ -630,6 +653,9 @@ namespace models
         /**
          * \brief Polls the background verification task without blocking.
          * \return nullopt if no task has been started; otherwise a VerifyStatus snapshot.
+         * \remarks Any exception escaping VerifyReleaseIntegrity is caught and reported as
+         *          a human-readable failure in the returned result rather than propagating
+         *          out of this polling call.
          */
         [[nodiscard]] std::optional<VerifyStatus> GetVerifyStatus() const;
 
@@ -637,6 +663,11 @@ namespace models
          * \brief Discards the completed or in-progress verification task.
          */
         void ResetVerifyState();
+
+        /**
+         * \brief Blocks until the running verification task (if any) finishes.
+         */
+        void WaitForVerifyToFinish();
 
         /**
          * \brief Validates the Authenticode signature of a file and optionally pins the publisher.

--- a/tests/e2e/run-lifecycle-e2e.ps1
+++ b/tests/e2e/run-lifecycle-e2e.ps1
@@ -1,0 +1,345 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Async-shutdown lifecycle E2E tests for the interactive updater window.
+
+.DESCRIPTION
+    run-e2e.ps1 only exercises the headless --silent-update path, which never touches
+    the WM_QUIT close handling, the changelog image-download task, or the setup
+    stop_source wiring in main.cpp. This script instead launches the interactive
+    updater, drives it to the wizard's "download and install" step via the E2E-only
+    NV_E2E_AUTO_ADVANCE env var (main.cpp), waits until a background task (changelog
+    image fetch, release download, or child setup process) is genuinely in flight
+    against an artificially delayed server response, then posts WM_CLOSE to the main
+    window -- exactly what a user clicking the titlebar X does -- and asserts the
+    process exits within a bounded time with a deterministic, non-crash exit code.
+
+    Without the async-lifecycle fix, closing while a task is in flight risks either an
+    indefinite hang (dropping a not-yet-ready std::shared_future from std::async blocks
+    the destructor until the task completes) or a use-after-free (the changelog's
+    image-download task keeps calling into curl/D3D after curlpp::terminate() and
+    CleanupDeviceD3D() have already run). Bounded, crash-free exit is the pass criterion.
+
+.PARAMETER MainBin
+    Path to the main E2E updater binary (e2e_Main_Updater.exe), built with
+    NV_FLAGS_ALLOW_HTTP_DOWNLOAD (required for both the localhost server URL and the
+    NV_E2E_AUTO_ADVANCE wizard hook, which only compiles into that build).
+
+.PARAMETER ArtifactsDir
+    E2E_ARTIFACTS_DIR: directory containing payload.zip and setup.exe (same fixtures
+    used by run-e2e.ps1).
+
+.PARAMETER ServerDir
+    Path to the examples/server project directory (for locating the pre-built server.dll).
+
+.PARAMETER LogDir
+    Directory where per-scenario log files are written.
+#>
+param(
+    [Parameter(Mandatory)]
+    [string] $MainBin,
+
+    [Parameter(Mandatory)]
+    [string] $ArtifactsDir,
+
+    [Parameter(Mandatory)]
+    [string] $ServerDir,
+
+    [string] $LogDir = (Join-Path $PSScriptRoot 'e2e-lifecycle-logs')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path $LogDir) { Remove-Item $LogDir -Recurse -Force }
+New-Item -ItemType Directory -Path $LogDir | Out-Null
+
+# ---------------------------------------------------------------------------
+# Win32 helpers: find the updater's top-level window by owning PID and post
+# WM_CLOSE to it, the same message DefWindowProc sends when the titlebar X /
+# Alt+F4 is used.
+# ---------------------------------------------------------------------------
+
+Add-Type -Namespace ViciusE2E -Name Win32 -MemberDefinition @'
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+    public static extern bool PostMessageW(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    public const uint WM_CLOSE = 0x0010;
+'@
+
+function Find-MainWindow {
+    param([int] $ProcessId, [int] $TimeoutMs = 15000)
+
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMs)
+    while ((Get-Date) -lt $deadline) {
+        $found = [IntPtr]::Zero
+        $callback = [ViciusE2E.Win32+EnumWindowsProc] {
+            param([IntPtr]$hWnd, [IntPtr]$lParam)
+            [uint32]$ownerPid = 0
+            [void][ViciusE2E.Win32]::GetWindowThreadProcessId($hWnd, [ref]$ownerPid)
+            if ($ownerPid -eq $ProcessId -and [ViciusE2E.Win32]::IsWindowVisible($hWnd)) {
+                $script:found = $hWnd
+                return $false
+            }
+            return $true
+        }
+        $script:found = [IntPtr]::Zero
+        [void][ViciusE2E.Win32]::EnumWindows($callback, [IntPtr]::Zero)
+        if ($script:found -ne [IntPtr]::Zero) { return $script:found }
+        Start-Sleep -Milliseconds 100
+    }
+    return [IntPtr]::Zero
+}
+
+function Send-WmClose {
+    param([IntPtr] $HWnd)
+    [void][ViciusE2E.Win32]::PostMessageW($HWnd, [ViciusE2E.Win32]::WM_CLOSE, [IntPtr]::Zero, [IntPtr]::Zero)
+}
+
+# ---------------------------------------------------------------------------
+# Server lifecycle (mirrors run-e2e.ps1)
+# ---------------------------------------------------------------------------
+
+function Start-E2EServer {
+    Write-Host 'Building example server...'
+    & dotnet build $ServerDir -c Release --nologo -v quiet | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "dotnet build failed with exit $LASTEXITCODE" }
+
+    Write-Host 'Starting example server...'
+    $env:VICIUS_E2E        = '1'
+    $env:E2E_ARTIFACTS_DIR = $ArtifactsDir
+    $env:ASPNETCORE_URLS   = 'http://localhost:5200'
+    $env:ASPNETCORE_ENVIRONMENT = 'Development'
+
+    $serverDll = Join-Path $ServerDir 'bin' 'Release' 'net10.0' 'server.dll'
+
+    $job = Start-Process `
+        -FilePath 'dotnet' `
+        -ArgumentList $serverDll `
+        -PassThru `
+        -NoNewWindow `
+        -RedirectStandardOutput (Join-Path $LogDir 'server.stdout.txt') `
+        -RedirectStandardError  (Join-Path $LogDir 'server.stderr.txt')
+
+    $readyUrl = 'http://localhost:5200/api/vicius/master/schema.json'
+    $deadline = (Get-Date).AddSeconds(60)
+    $ready = $false
+    Write-Host "  Waiting for server readiness at $readyUrl ..."
+    while ((Get-Date) -lt $deadline) {
+        if ($job.HasExited) {
+            $stderr = Get-Content (Join-Path $LogDir 'server.stderr.txt') -Raw -ErrorAction SilentlyContinue
+            throw "Example server exited unexpectedly (exit code $($job.ExitCode)).`nRecent stderr:`n$stderr"
+        }
+        try {
+            $r = Invoke-WebRequest -Uri $readyUrl -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+            if ($r.StatusCode -eq 200) { $ready = $true; break }
+        } catch { }
+        Start-Sleep -Milliseconds 500
+    }
+
+    if (-not $ready) {
+        Stop-Process -Id $job.Id -Force -ErrorAction SilentlyContinue
+        throw 'Example server did not become ready within 60 seconds.'
+    }
+
+    Write-Host "  Server is ready (PID $($job.Id))."
+    return $job
+}
+
+function Stop-E2EServer([System.Diagnostics.Process] $job) {
+    if ($job -and -not $job.HasExited) {
+        Write-Host 'Stopping example server...'
+        Stop-Process -Id $job.Id -Force -ErrorAction SilentlyContinue
+        $job.WaitForExit(5000) | Out-Null
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario runner
+# ---------------------------------------------------------------------------
+
+$results = [System.Collections.Generic.List[hashtable]]::new()
+
+function Invoke-LifecycleScenario {
+    param(
+        [string]    $Name,
+        [string]    $ExeName,
+        [hashtable] $Sidecar,
+        [int]       $WaitBeforeCloseMs,     # how long to let the app run before sending WM_CLOSE
+        [int]       $BoundedExitTimeoutMs,  # process must exit within this long after WM_CLOSE
+        [hashtable] $ExtraEnv = @{}
+    )
+
+    Write-Host "`n──────────────────────────────────────────────────────────"
+    Write-Host "  Scenario: $Name"
+    Write-Host "──────────────────────────────────────────────────────────"
+
+    $workDir = Join-Path $env:TEMP "vicius-e2e-lifecycle-$Name-$(New-Guid)"
+    New-Item -ItemType Directory -Path $workDir | Out-Null
+
+    $exePath = Join-Path $workDir $ExeName
+    Copy-Item -Path $MainBin -Destination $exePath
+
+    $sidecarPath = Join-Path $workDir $Sidecar.Name
+    $Sidecar.Content | Set-Content -Path $sidecarPath -Encoding utf8
+
+    $logFile = Join-Path $LogDir "$Name.log"
+
+    $prevEnv = @{}
+    foreach ($k in $ExtraEnv.Keys) {
+        $prevEnv[$k] = [System.Environment]::GetEnvironmentVariable($k)
+        [System.Environment]::SetEnvironmentVariable($k, $ExtraEnv[$k])
+    }
+    [System.Environment]::SetEnvironmentVariable('NV_E2E_AUTO_ADVANCE', '1')
+
+    $result = @{ Name = $Name; Passed = $false; Note = '' }
+
+    try {
+        $proc = Start-Process `
+            -FilePath $exePath `
+            -ArgumentList '--force-local-version', '0.0.1', '--ignore-busy-state',
+                          '--log-to-file', $logFile, '--log-level', 'debug' `
+            -PassThru -NoNewWindow
+
+        try {
+            Write-Host "  Launched PID $($proc.Id); waiting for main window..."
+            $hwnd = Find-MainWindow -ProcessId $proc.Id -TimeoutMs 15000
+            if ($hwnd -eq [IntPtr]::Zero) {
+                $result.Note = 'Main window never appeared'
+                return $result
+            }
+
+            Write-Host "  Window found; waiting ${WaitBeforeCloseMs}ms for background task(s) to start..."
+            Start-Sleep -Milliseconds $WaitBeforeCloseMs
+
+            if ($proc.HasExited) {
+                $result.Note = "Process already exited before WM_CLOSE was sent (exit code $($proc.ExitCode))"
+                return $result
+            }
+
+            Write-Host '  Sending WM_CLOSE...'
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            Send-WmClose -HWnd $hwnd
+
+            $exited = $proc.WaitForExit($BoundedExitTimeoutMs)
+            $sw.Stop()
+
+            if (-not $exited) {
+                $result.Note = "Did not exit within ${BoundedExitTimeoutMs}ms of WM_CLOSE (hang) - killing"
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+                return $result
+            }
+
+            $elapsedMs = $sw.ElapsedMilliseconds
+            $exitCode = $proc.ExitCode
+
+            Write-Host "  Exited $elapsedMs`ms after WM_CLOSE with code $exitCode"
+
+            # A crash surfaces as an NTSTATUS-style exit code (e.g. access violation is
+            # 0xC0000005 == -1073741819) rather than one of the small, well-known NV_* codes.
+            if ($exitCode -lt 0 -or $exitCode -gt 255) {
+                $result.Note = "Crash-shaped exit code $exitCode (0x$('{0:X8}' -f $exitCode))"
+                return $result
+            }
+
+            $result.Passed = $true
+            $result.Note = "Clean exit, code $exitCode, ${elapsedMs}ms after WM_CLOSE"
+            return $result
+        }
+        finally {
+            if (-not $proc.HasExited) {
+                Write-Warning "  Scenario '$Name' left the process running; force-killing."
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    finally {
+        foreach ($k in $prevEnv.Keys) {
+            [System.Environment]::SetEnvironmentVariable($k, $prevEnv[$k])
+        }
+        [System.Environment]::SetEnvironmentVariable('NV_E2E_AUTO_ADVANCE', $null)
+        Remove-Item -Path $workDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+$serverJob = Start-E2EServer
+
+try {
+    # Server delays both the changelog image and the release download by 8s
+    # (E2ELifecycleEndpoint.cs), so closing ~2s after the window appears catches both
+    # tasks genuinely in flight. Bounded exit timeout is comfortably under the 8s delay:
+    # the release download aborts fast (curl progress callback observes
+    # abortDownloadRequested within ~1s) and the image fetch is capped by its own 5s
+    # HTTP timeout in DownloadImageTexture, so total teardown must complete well inside it.
+    $results.Add((Invoke-LifecycleScenario `
+        -Name 'CloseDuringDownloadAndImageFetch' `
+        -ExeName 'e2e_LifecycleDownload_Updater.exe' `
+        -Sidecar @{
+            Name    = 'e2e_LifecycleDownload_Updater.json'
+            Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/Lifecycle/updates.json"}}'
+        } `
+        -WaitBeforeCloseMs 2000 `
+        -BoundedExitTimeoutMs 7000))
+
+    # setup.exe sleeps for E2E_EXIT_DELAY_MS (inherited from this process's environment)
+    # before exiting, so closing ~2.5s after the window appears (enough time for the fast
+    # local download+verify to finish and the child process to launch) lands squarely
+    # inside "setup is running". The cooperative stop_source (main.cpp WM_QUIT handling)
+    # must cut the wait short well before the 8s sleep elapses.
+    $results.Add((Invoke-LifecycleScenario `
+        -Name 'CloseDuringSetup' `
+        -ExeName 'e2e_LifecycleSetup_Updater.exe' `
+        -Sidecar @{
+            Name    = 'e2e_LifecycleSetup_Updater.json'
+            Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/LifecycleSetup/updates.json"}}'
+        } `
+        -WaitBeforeCloseMs 2500 `
+        -BoundedExitTimeoutMs 5000 `
+        -ExtraEnv @{ E2E_EXIT_DELAY_MS = '8000' }))
+}
+finally {
+    Stop-E2EServer $serverJob
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host "`n──────────────────────────────────────────────────────────"
+Write-Host '  Lifecycle E2E summary'
+Write-Host '──────────────────────────────────────────────────────────'
+
+$failed = 0
+foreach ($r in $results) {
+    if ($r.Passed) {
+        $mark = 'PASS'
+    } else {
+        $mark = 'FAIL'
+        $failed++
+    }
+    Write-Host "  [$mark] $($r.Name): $($r.Note)"
+}
+
+if ($failed -gt 0) {
+    Write-Host "`n$failed scenario(s) failed." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nAll lifecycle scenarios passed." -ForegroundColor Green
+exit 0

--- a/tests/e2e/run-lifecycle-e2e.ps1
+++ b/tests/e2e/run-lifecycle-e2e.ps1
@@ -9,17 +9,19 @@
     the WM_QUIT close handling, the changelog image-download task, or the setup
     stop_source wiring in main.cpp. This script instead launches the interactive
     updater, drives it to the wizard's "download and install" step via the E2E-only
-    NV_E2E_AUTO_ADVANCE env var (main.cpp), waits until a background task (changelog
+    NV_E2E_AUTO_ADVANCE env var (main.cpp), polls until a background task (changelog
     image fetch, release download, or child setup process) is genuinely in flight
     against an artificially delayed server response, then posts WM_CLOSE to the main
     window -- exactly what a user clicking the titlebar X does -- and asserts the
-    process exits within a bounded time with a deterministic, non-crash exit code.
+    process exits within a bounded time with an explicitly allowlisted NV_*/clean
+    shutdown exit code.
 
     Without the async-lifecycle fix, closing while a task is in flight risks either an
     indefinite hang (dropping a not-yet-ready std::shared_future from std::async blocks
     the destructor until the task completes) or a use-after-free (the changelog's
     image-download task keeps calling into curl/D3D after curlpp::terminate() and
-    CleanupDeviceD3D() have already run). Bounded, crash-free exit is the pass criterion.
+    CleanupDeviceD3D() have already run). Bounded, crash-free exit with an expected
+    code is the pass criterion.
 
 .PARAMETER MainBin
     Path to the main E2E updater binary (e2e_Main_Updater.exe), built with
@@ -167,6 +169,53 @@ function Stop-E2EServer([System.Diagnostics.Process] $job) {
 }
 
 # ---------------------------------------------------------------------------
+# Readiness polling: wait for explicit evidence that the targeted background
+# task has started (log marker and/or child process), rather than a fixed sleep.
+# ---------------------------------------------------------------------------
+
+function Wait-LifecycleReady {
+    param(
+        [System.Diagnostics.Process] $Process,
+        [string] $LogFile,
+        [string] $ReadyLogContains = '',
+        [switch] $ReadyAnyChildProcess,  # setup is launched from a GetTempFileName path, not setup.exe
+        [int]    $TimeoutMs = 15000
+    )
+
+    if (-not $ReadyLogContains -and -not $ReadyAnyChildProcess) {
+        throw 'Wait-LifecycleReady requires ReadyLogContains and/or ReadyAnyChildProcess'
+    }
+
+    $deadline = (Get-Date).AddMilliseconds($TimeoutMs)
+    while ((Get-Date) -lt $deadline) {
+        if ($Process.HasExited) {
+            return @{ Ready = $false; Reason = "Process exited before readiness (exit code $($Process.ExitCode))" }
+        }
+
+        if ($ReadyLogContains -and (Test-Path -LiteralPath $LogFile)) {
+            if (Select-String -LiteralPath $LogFile -Pattern $ReadyLogContains -SimpleMatch -Quiet) {
+                return @{ Ready = $true; Reason = "log marker '$ReadyLogContains'" }
+            }
+        }
+
+        if ($ReadyAnyChildProcess) {
+            $children = @(Get-CimInstance Win32_Process -Filter "ParentProcessId=$($Process.Id)" -ErrorAction SilentlyContinue)
+            if ($children.Count -gt 0) {
+                return @{ Ready = $true; Reason = "child process '$($children[0].Name)' (PID $($children[0].ProcessId))" }
+            }
+        }
+
+        Start-Sleep -Milliseconds 100
+    }
+
+    $wanted = @(
+        $(if ($ReadyLogContains) { "log marker '$ReadyLogContains'" }),
+        $(if ($ReadyAnyChildProcess) { 'any child process' })
+    ) | Where-Object { $_ }
+    return @{ Ready = $false; Reason = "Timed out after ${TimeoutMs}ms waiting for $($wanted -join ' or ')" }
+}
+
+# ---------------------------------------------------------------------------
 # Scenario runner
 # ---------------------------------------------------------------------------
 
@@ -174,12 +223,15 @@ $results = [System.Collections.Generic.List[hashtable]]::new()
 
 function Invoke-LifecycleScenario {
     param(
-        [string]    $Name,
-        [string]    $ExeName,
-        [hashtable] $Sidecar,
-        [int]       $WaitBeforeCloseMs,     # how long to let the app run before sending WM_CLOSE
-        [int]       $BoundedExitTimeoutMs,  # process must exit within this long after WM_CLOSE
-        [hashtable] $ExtraEnv = @{}
+        [string]   $Name,
+        [string]   $ExeName,
+        [hashtable]$Sidecar,
+        [int[]]    $ExpectedExitCodes,      # allowlisted NV_*/clean shutdown codes for this scenario
+        [string]   $ReadyLogContains = '',  # log substring proving the target task started
+        [switch]   $ReadyAnyChildProcess,   # any child of the updater (setup is a temp-named PE)
+        [int]      $ReadyTimeoutMs = 15000, # fail if readiness evidence never appears
+        [int]      $BoundedExitTimeoutMs,   # process must exit within this long after WM_CLOSE
+        [hashtable]$ExtraEnv = @{}
     )
 
     Write-Host "`n──────────────────────────────────────────────────────────"
@@ -221,15 +273,28 @@ function Invoke-LifecycleScenario {
                 return $result
             }
 
-            Write-Host "  Window found; waiting ${WaitBeforeCloseMs}ms for background task(s) to start..."
-            Start-Sleep -Milliseconds $WaitBeforeCloseMs
+            Write-Host "  Window found; polling for background-task readiness..."
+            $readyParams = @{
+                Process             = $proc
+                LogFile             = $logFile
+                ReadyLogContains    = $ReadyLogContains
+                TimeoutMs           = $ReadyTimeoutMs
+            }
+            if ($ReadyAnyChildProcess) { $readyParams.ReadyAnyChildProcess = $true }
+            $ready = Wait-LifecycleReady @readyParams
+
+            if (-not $ready.Ready) {
+                $result.Note = $ready.Reason
+                return $result
+            }
+
+            Write-Host "  Ready ($($ready.Reason)); sending WM_CLOSE..."
 
             if ($proc.HasExited) {
                 $result.Note = "Process already exited before WM_CLOSE was sent (exit code $($proc.ExitCode))"
                 return $result
             }
 
-            Write-Host '  Sending WM_CLOSE...'
             $sw = [System.Diagnostics.Stopwatch]::StartNew()
             Send-WmClose -HWnd $hwnd
 
@@ -251,6 +316,14 @@ function Invoke-LifecycleScenario {
             # 0xC0000005 == -1073741819) rather than one of the small, well-known NV_* codes.
             if ($exitCode -lt 0 -or $exitCode -gt 255) {
                 $result.Note = "Crash-shaped exit code $exitCode (0x$('{0:X8}' -f $exitCode))"
+                return $result
+            }
+
+            # Ordinary non-crash codes that are not on this scenario's allowlist are rejects
+            # (e.g. NV_S_UPDATE_FINISHED=203 would mean we closed after the work finished).
+            if ($ExpectedExitCodes -notcontains $exitCode) {
+                $allowed = ($ExpectedExitCodes | ForEach-Object { $_ }) -join ', '
+                $result.Note = "Unexpected exit code $exitCode (allowed: $allowed)"
                 return $result
             }
 
@@ -281,12 +354,14 @@ function Invoke-LifecycleScenario {
 $serverJob = Start-E2EServer
 
 try {
-    # Server delays both the changelog image and the release download by 8s
-    # (E2ELifecycleEndpoint.cs), so closing ~2s after the window appears catches both
-    # tasks genuinely in flight. Bounded exit timeout is comfortably under the 8s delay:
-    # the release download aborts fast (curl progress callback observes
-    # abortDownloadRequested within ~1s) and the image fetch is capped by its own 5s
-    # HTTP timeout in DownloadImageTexture, so total teardown must complete well inside it.
+    # Server delays both the changelog image and the release artifact by 8s
+    # (E2ELifecycleEndpoint.cs). Poll until the updater log shows the release
+    # download has started — at that point the delayed HTTP transfer (and the
+    # in-flight image fetch started from the same summary) are genuinely running.
+    # Closing then must exit well under the remaining delay via cooperative abort.
+    # Expected exit: ERROR_SUCCESS (0) — WM_CLOSE -> WM_DESTROY -> PostQuitMessage(0)
+    # leaves main.cpp's status at its ERROR_SUCCESS default when no wizard status
+    # was posted first.
     $results.Add((Invoke-LifecycleScenario `
         -Name 'CloseDuringDownloadAndImageFetch' `
         -ExeName 'e2e_LifecycleDownload_Updater.exe' `
@@ -294,14 +369,17 @@ try {
             Name    = 'e2e_LifecycleDownload_Updater.json'
             Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/Lifecycle/updates.json"}}'
         } `
-        -WaitBeforeCloseMs 2000 `
+        -ExpectedExitCodes @(0) `
+        -ReadyLogContains 'Starting release download from' `
+        -ReadyTimeoutMs 15000 `
         -BoundedExitTimeoutMs 7000))
 
-    # setup.exe sleeps for E2E_EXIT_DELAY_MS (inherited from this process's environment)
-    # before exiting, so closing ~2.5s after the window appears (enough time for the fast
-    # local download+verify to finish and the child process to launch) lands squarely
-    # inside "setup is running". The cooperative stop_source (main.cpp WM_QUIT handling)
-    # must cut the wait short well before the 8s sleep elapses.
+    # setup.exe sleeps for E2E_EXIT_DELAY_MS (inherited) before exiting. Poll until
+    # the child setup process is actually running (or the launch log marker appears),
+    # then close — the cooperative stop_source must cut the wait short well before
+    # the 8s sleep elapses. Expected exit: ERROR_SUCCESS (0) for the same
+    # PostQuitMessage path; NV_S_CLOSED_WHILE_UPDATER_RUNNING (208) is also allowed
+    # if a frame races and posts the cancelled-setup status before quit.
     $results.Add((Invoke-LifecycleScenario `
         -Name 'CloseDuringSetup' `
         -ExeName 'e2e_LifecycleSetup_Updater.exe' `
@@ -309,7 +387,10 @@ try {
             Name    = 'e2e_LifecycleSetup_Updater.json'
             Content = '{"instance":{"serverUrlTemplate":"http://localhost:5200/api/e2e/LifecycleSetup/updates.json"}}'
         } `
-        -WaitBeforeCloseMs 2500 `
+        -ExpectedExitCodes @(0, 208) `
+        -ReadyLogContains 'Setup process launched successfully' `
+        -ReadyAnyChildProcess `
+        -ReadyTimeoutMs 20000 `
         -BoundedExitTimeoutMs 5000 `
         -ExtraEnv @{ E2E_EXIT_DELAY_MS = '8000' }))
 }


### PR DESCRIPTION
## Summary

PR 3 of the runtime remediation plan: async shutdown and task ownership.

Closing the updater window while a background task (setup, verification, or
changelog image fetch) is still running previously risked either an
indefinite hang or a use-after-free:

- Dropping a not-yet-ready `std::shared_future` created via `std::async`
  blocks the owning destructor until the task completes. `InstanceConfig`'s
  destructor already handled `downloadTask` this way but not `setupTask` or
  `verifyTask`, and `main.cpp`'s `WM_QUIT` handling never requested a stop
  or waited for either, so closing during setup could hang for the full
  duration of an external installer (confirmed via A/B testing below).
- The changelog renderer's image-download task lives in a function-local
  `static` object that outlives `main()`. It captures `g_pd3dDevice` and
  calls into libcurl/WIC on a background thread with no shutdown hook, so a
  download in flight when `curlpp::terminate()` and `CleanupDeviceD3D()`
  run is a genuine use-after-free race.

### Changes

- `main.cpp`: `WM_QUIT` handling now calls `stopSource.request_stop()` and
  waits for the setup/verify tasks (in addition to the existing download
  wait) before tearing down D3D/ImGui, and calls the new
  `markdown::Shutdown()` before that teardown.
- `markdown.cpp`/`UI.h`: added `markdown::Shutdown()`, which stops accepting
  new image downloads and blocks until any in-flight one finishes.
- `InstanceConfig.Setup.cpp`/`InstanceConfig.Security.cpp`: made
  `ResetSetupState()` nonblocking to match the existing `ResetVerifyState()`
  guard, and added explicit `WaitForSetupToFinish()` /
  `WaitForVerifyToFinish()` completion APIs.
- `InstanceConfig.cpp`: the destructor now calls both new `WaitFor...`
  methods as a backstop for any exit path other than the normal `WM_QUIT`
  handling.
- `InstanceConfig.Setup.cpp`/`InstanceConfig.Security.cpp`/`InstanceConfig.Download.cpp`:
  wrapped the setup/verify/download polling `.get()` calls in `try`/`catch`
  so an exception can never unwind through the ImGui/DirectX frame.

### Test coverage

`run-e2e.ps1` only exercises the headless `--silent-update` path, which
never touches `WM_QUIT`, the changelog image task, or the setup
`stop_source`. Added a new, separate harness,
`tests/e2e/run-lifecycle-e2e.ps1`, that drives the **interactive** window:

- A new E2E-only `NV_E2E_AUTO_ADVANCE` env var (checked in `main.cpp`,
  compiled only into `NV_FLAGS_ALLOW_HTTP_DOWNLOAD` test builds) lets the
  harness advance the wizard to the download/verify/install steps without
  simulating mouse clicks against an ImGui window, which has no OS
  accessibility tree.
- Two new example-server endpoints (`E2ELifecycleEndpoint`,
  `E2ELifecycleSetupEndpoint`) serve an artificially delayed
  image/download response and a `setup.exe` that sleeps via a new
  `E2E_EXIT_DELAY_MS` env var, so a background task is genuinely in flight
  when the harness acts.
- The harness posts `WM_CLOSE` (via `user32.dll` P/Invoke, the same message
  the titlebar X sends) to the live window while that task is in flight,
  then asserts the process exits within a bounded time with a non-crash
  exit code.
- Wired into CI (`build.yml`) right after the existing E2E suite.

**A/B validation:** temporarily reverted just the `stopSource.request_stop()`
/ `WaitFor*ToFinish()` wiring and re-ran the harness — `CloseDuringSetup`
went from exiting 43ms after `WM_CLOSE` to hanging past the 5s bounded
timeout (killed), confirming the fix actually changes behavior rather than
being a no-op. Restored the fix and reran to confirm both scenarios pass
again.

## Test plan

- [x] x64 Release solution build (`vīcĭus.sln`) succeeds.
- [x] New `tests/e2e/run-lifecycle-e2e.ps1`: `CloseDuringDownloadAndImageFetch`
      and `CloseDuringSetup` both pass (bounded, clean exit).
- [x] A/B: reverting the `WM_QUIT`/destructor fix reproduces a hang in
      `CloseDuringSetup`; restoring the fix passes again.
- [x] Full existing `tests/e2e/run-e2e.ps1` suite: 26/26 scenarios pass
      (no regressions from the exception-handling/nonblocking-reset changes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by coordinating cancellation and waiting for in-flight download, setup, verification, and changelog image activity to complete.
  * Prevented exceptions from async background operations from escaping and destabilizing the interface.
  * Blocked new changelog image downloads once shutdown begins.
* **Tests**
  * Extended E2E lifecycle coverage with async-shutdown behavior checks and lifecycle log collection.
  * Enhanced E2E test server/fixtures to support controlled startup and response delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->