### PR TITLE
Harden Win32 process launch and handle ownership

### DIFF
--- a/dll/dll.cpp
+++ b/dll/dll.cpp
@@ -186,6 +186,44 @@ static std::expected<void, std::string> VerifyAuthenticode(const std::wstring& f
 // ============================================================================
 // Case-insensitive hex string comparison (for checksum matching)
 // ============================================================================
+/**
+ * \brief Quotes and escapes a single argument value for safe inclusion in a
+ * CreateProcess command string that will be parsed by CommandLineToArgvW-style rules.
+ * Duplicated from src/InstanceConfig.Updater.cpp's QuoteArg: this DLL is a separate
+ * project/compilation unit that does not link against src/, so shared helpers are
+ * intentionally kept as small local copies rather than introducing a cross-project
+ * dependency (see PR history for src/Http.h for the same rationale).
+ */
+static std::string QuoteArg(const std::string& arg)
+{
+    std::string out;
+    out.reserve(arg.size() + 4);
+    out += '"';
+    size_t backslashes = 0;
+    for (const char c : arg)
+    {
+        if (c == '\\')
+        {
+            ++backslashes;
+        }
+        else if (c == '"')
+        {
+            out.append(backslashes * 2, '\\');
+            out += "\\\"";
+            backslashes = 0;
+        }
+        else
+        {
+            out.append(backslashes, '\\');
+            out += c;
+            backslashes = 0;
+        }
+    }
+    out.append(backslashes * 2, '\\');
+    out += '"';
+    return out;
+}
+
 static bool IHexEqual(const std::string& a, const std::string& b)
 {
     if (a.size() != b.size()) return false;
@@ -666,18 +704,30 @@ EXTERN_C DLL_API void CALLBACK PerformUpdate(HWND hwnd, HINSTANCE hinst, LPSTR l
         si.dwFlags = STARTF_USESHOWWINDOW;
         si.wShowWindow = SW_HIDE;
 
+        const std::string originalStr = original.string();
+
         std::stringstream argsStream;
-        // build CLI args
+        // build CLI args; argv[0] is quoted consistently with lpApplicationName below
+        // instead of relying on std::filesystem::path's own (differently-escaping)
+        // ostream inserter.
         argsStream
-            << original // main executable
+            << QuoteArg(originalStr) // main executable
             << " --install" // install steps might have changed in new version
             << " --skip-self-update"; // extra protection to not end up in a loop
         const auto launchArgs = argsStream.str();
         spdlog::debug("launchArgs = {}", launchArgs);
 
+        // lpApplicationName is the already-resolved, absolute path to the just-swapped-in
+        // main executable, so it is passed explicitly rather than relying on lpCommandLine
+        // parsing/searching to find it. CreateProcessA may write into lpCommandLine while
+        // parsing/expanding arguments, so it must be a writable buffer, never a
+        // std::string's internal storage (even via const_cast).
+        std::vector<char> cmdLineBuf(launchArgs.begin(), launchArgs.end());
+        cmdLineBuf.push_back('\0');
+
         if (!CreateProcessA(
-            nullptr,
-            const_cast<LPSTR>(launchArgs.c_str()),
+            originalStr.c_str(),
+            cmdLineBuf.data(),
             nullptr,
             nullptr,
             FALSE,

--- a/examples/e2e-setup-stub/Program.cs
+++ b/examples/e2e-setup-stub/Program.cs
@@ -7,5 +7,18 @@
 // The exit code can be overridden for negative-test variants by setting the
 // E2E_EXIT_CODE environment variable before launching the updater.
 
+// Process-argument round-trip lifecycle test: when E2E_ARGS_LOG_FILE is set (CreateProcess
+// inherits the parent's environment by default, so setting this on the updater process
+// before launch propagates all the way down to this child), write each argv element
+// received (i.e. exactly what CreateProcessA's own argv-splitting rules produced from the
+// manifest's launchArguments, appended verbatim by ExecuteSetup) to that file, one per
+// line, so the harness can assert spaces/quotes/trailing backslashes survived intact.
+string? argsLogFile = Environment.GetEnvironmentVariable("E2E_ARGS_LOG_FILE");
+if (!string.IsNullOrEmpty(argsLogFile))
+{
+    string[] receivedArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+    File.WriteAllLines(argsLogFile, receivedArgs);
+}
+
 int exitCode = int.TryParse(Environment.GetEnvironmentVariable("E2E_EXIT_CODE"), out int c) ? c : 0;
 Environment.Exit(exitCode);

--- a/examples/server/Endpoints/E2E/E2EProcessArgsRoundTripEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EProcessArgsRoundTripEndpoint.cs
@@ -1,0 +1,91 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: update available, EXE installer (setup stub), whose manifest-supplied
+///     <c>launchArguments</c> raw command-line fragment contains a quoted argument with an
+///     embedded space, a quoted argument with an embedded escaped double-quote, and a quoted
+///     argument ending in an escaped trailing backslash.
+///     Regression coverage for src/InstanceConfig.Setup.cpp's process launch: proves the
+///     writable command-line buffer and explicit application name changes still deliver
+///     these tokens to the child process unchanged (see tests/e2e/run-e2e.ps1's
+///     ProcessArgsRoundTrip scenario, which reads them back via E2E_ARGS_LOG_FILE).
+///     Expected updater exit code: <c>NV_S_UPDATE_FINISHED = 203</c>.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2EProcessArgsRoundTripEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/ProcessArgsRoundTrip/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string exePath = Path.Combine(artifactsDir, "setup.exe");
+        if (!File.Exists(exePath))
+            ThrowError("E2E fixture 'setup.exe' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(exePath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        // Built via explicit concatenation (rather than an escaped/verbatim literal) so the
+        // exact intended bytes are unambiguous. Quote (Q) and backslash (B) are single
+        // characters; the resulting raw Windows command-line fragment is:
+        //     "arg with spaces" "quote\"inside" "trailingback\\"
+        // which CommandLineToArgvW-style parsing must split into exactly three argv tokens:
+        //     arg with spaces | quote"inside | trailingback\
+        const string q = "\"";
+        const string b = "\\";
+        string launchArguments = q + "arg with spaces" + q + " " +
+                                  q + "quote" + b + q + "inside" + q + " " +
+                                  q + "trailingback" + b + b + q;
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E ProcessArgsRoundTrip Updater"
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Process Args Round Trip Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/artifacts/setup.exe",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    },
+                    LaunchArguments = launchArguments,
+                    ExitCode = new ExitCodeCheck
+                    {
+                        SuccessCodes = { 0 }
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/src/InstanceConfig.Security.cpp
+++ b/src/InstanceConfig.Security.cpp
@@ -11,8 +11,9 @@ namespace
 {
     /**
      * \brief Hash a file with MD5 and return the hex digest.
+     * \return Hex digest on success; empty string on I/O failure or if stopToken is signalled.
      */
-    std::string HashFileMD5(const std::string& filePath)
+    std::string HashFileMD5(const std::string& filePath, const std::stop_token& stopToken)
     {
         MD5 alg;
         std::ifstream file(filePath, std::ios::binary);
@@ -22,6 +23,7 @@ namespace
         std::vector<char> buf(chunkSize);
         while (!file.eof())
         {
+            if (stopToken.stop_requested()) return {};
             file.read(buf.data(), buf.size());
             const std::streamsize n = file.gcount();
             if (n > 0) alg.add(buf.data(), n);
@@ -29,7 +31,7 @@ namespace
         return alg.getHash();
     }
 
-    std::string HashFileSHA1(const std::string& filePath)
+    std::string HashFileSHA1(const std::string& filePath, const std::stop_token& stopToken)
     {
         SHA1 alg;
         std::ifstream file(filePath, std::ios::binary);
@@ -39,6 +41,7 @@ namespace
         std::vector<char> buf(chunkSize);
         while (!file.eof())
         {
+            if (stopToken.stop_requested()) return {};
             file.read(buf.data(), buf.size());
             const std::streamsize n = file.gcount();
             if (n > 0) alg.add(buf.data(), n);
@@ -46,7 +49,7 @@ namespace
         return alg.getHash();
     }
 
-    std::string HashFileSHA256(const std::string& filePath)
+    std::string HashFileSHA256(const std::string& filePath, const std::stop_token& stopToken)
     {
         SHA256 alg;
         std::ifstream file(filePath, std::ios::binary);
@@ -56,6 +59,7 @@ namespace
         std::vector<char> buf(chunkSize);
         while (!file.eof())
         {
+            if (stopToken.stop_requested()) return {};
             file.read(buf.data(), buf.size());
             const std::streamsize n = file.gcount();
             if (n > 0) alg.add(buf.data(), n);
@@ -198,10 +202,14 @@ std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrityA
 
     try
     {
-        verifyTask = std::async(std::launch::async, &InstanceConfig::VerifyReleaseIntegrity, this);
+        // Fresh stop_source per launch so a prior shutdown cancel cannot poison a retry.
+        verifyStopSource.emplace();
+        verifyTask = std::async(std::launch::async, &InstanceConfig::VerifyReleaseIntegrity, this,
+                                std::stop_token{verifyStopSource->get_token()});
     }
     catch (const std::system_error& e)
     {
+        verifyStopSource.reset();
         return std::unexpected(std::format("Failed to start verification thread: {}", e.what()));
     }
 
@@ -251,7 +259,10 @@ void models::InstanceConfig::ResetVerifyState()
     // not-yet-ready shared_future that was created via std::async will block the
     // calling thread (the render thread) until the background work finishes.
     if (verifyTask->wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+    {
         verifyTask.reset();
+        verifyStopSource.reset();
+    }
     // Still running: leave it.  VerifyReleaseIntegrityAsync guards against re-launch,
     // and GetVerifyStatus will eventually report completion on a later frame.
 }
@@ -261,6 +272,11 @@ void models::InstanceConfig::WaitForVerifyToFinish()
     if (!verifyTask.has_value())
         return;
 
+    // Request cancel before waiting so a long hash does not pin shutdown; the task
+    // observes verifyStopSource at safe points between chunks.
+    if (verifyStopSource.has_value())
+        verifyStopSource->request_stop();
+
     verifyTask->wait();
 }
 
@@ -268,7 +284,7 @@ void models::InstanceConfig::WaitForVerifyToFinish()
 // Layer 1: Setup Checksum Verification
 // ============================================================================
 
-std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity()
+std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity(std::stop_token stopToken)
 {
     const auto& release = GetSelectedRelease();
     const auto tempFile = GetLocalReleaseTempFilePath(GetSelectedReleaseId());
@@ -288,20 +304,23 @@ std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity(
             return std::unexpected("Downloaded file not found for checksum verification");
         }
 
+        if (stopToken.stop_requested())
+            return std::unexpected("Verification cancelled");
+
         std::string computed;
         switch (hashCfg.checksumAlg)
         {
             case ChecksumAlgorithm::MD5:
                 spdlog::debug("Checksum verification: hashing with MD5");
-                computed = HashFileMD5(tempFile.string());
+                computed = HashFileMD5(tempFile.string(), stopToken);
                 break;
             case ChecksumAlgorithm::SHA1:
                 spdlog::debug("Checksum verification: hashing with SHA1");
-                computed = HashFileSHA1(tempFile.string());
+                computed = HashFileSHA1(tempFile.string(), stopToken);
                 break;
             case ChecksumAlgorithm::SHA256:
                 spdlog::debug("Checksum verification: hashing with SHA256");
-                computed = HashFileSHA256(tempFile.string());
+                computed = HashFileSHA256(tempFile.string(), stopToken);
                 break;
             case ChecksumAlgorithm::Invalid:
                 spdlog::error("Checksum verification: invalid algorithm specified in manifest");
@@ -310,6 +329,11 @@ std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity(
 
         if (computed.empty())
         {
+            if (stopToken.stop_requested())
+            {
+                spdlog::info("Checksum verification cancelled");
+                return std::unexpected("Verification cancelled");
+            }
             spdlog::error("Checksum verification: failed to hash file {}", tempFile.string());
             return std::unexpected("Failed to compute file checksum");
         }
@@ -334,6 +358,9 @@ std::expected<void, std::string> models::InstanceConfig::VerifyReleaseIntegrity(
         }
         spdlog::warn("Checksum verification: no checksum provided, skipping (relaxed mode)");
     }
+
+    if (stopToken.stop_requested())
+        return std::unexpected("Verification cancelled");
 
     //
     // --- Authenticode / publisher pin layer ---

--- a/src/InstanceConfig.Setup.cpp
+++ b/src/InstanceConfig.Setup.cpp
@@ -222,12 +222,22 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
 {
     if (this->terminateProcessBeforeUpdate.has_value())
     {
-        const auto terminatePID = GetProcessId(this->terminateProcessBeforeUpdate.value());
-        if (!TerminateProcess(this->terminateProcessBeforeUpdate.value(), 0))
+        const HANDLE handle = this->terminateProcessBeforeUpdate.value();
+        const auto terminatePID = GetProcessId(handle);
+        const BOOL terminated = TerminateProcess(handle, 0);
+        const DWORD terminateError = GetLastError();
+
+        // This is the handle's last use regardless of outcome; take ownership back here
+        // instead of leaving it for the destructor so it does not sit open for the
+        // duration of the (potentially lengthy) rest of setup.
+        CloseHandle(handle);
+        this->terminateProcessBeforeUpdate.reset();
+
+        if (!terminated)
         {
             // TODO: better user feedback; task dialog? Or explicit message in main UI page?
             return std::unexpected(std::format("Failed to terminate process before update: {}",
-                                               winapi::GetLastErrorStdStr()));
+                                               winapi::GetLastErrorStdStr(terminateError)));
         }
         spdlog::debug("Terminated PID {} due to {}", terminatePID, NV_CLI_PARAM_TERMINATE_PROCESS_BEFORE_UPDATE);
     }
@@ -452,8 +462,17 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
         PROCESS_INFORMATION updateProcessInfo = {};
 
         std::stringstream launchArgs;
-        launchArgs << tempFile;
+        // Quote consistently via QuoteArg rather than std::filesystem::path's ostream
+        // inserter (which escapes backslashes/quotes differently) so argv[0] matches
+        // what lpApplicationName below resolves to.
+        launchArgs << winapi::QuoteArg(tempFile.string());
 
+        // launchArguments is a manifest-supplied, already-tokenized raw Windows
+        // command-line fragment (e.g. "/S /D=C:\Program Files\App"), appended verbatim
+        // for compatibility with existing manifests. It is intentionally not re-parsed
+        // or re-quoted here: doing so would require a versioned manifest contract change,
+        // and installers' own argument grammars (MSI, InstallShield, NSIS, etc.) already
+        // expect this raw-fragment form.
         if (release.launchArguments.has_value())
         {
             launchArgs << " " << release.launchArguments.value();
@@ -464,7 +483,9 @@ std::expected<models::SetupResult, std::string> models::InstanceConfig::ExecuteS
         std::vector<char> cmdLine(args.begin(), args.end());
         cmdLine.push_back('\0');
 
-        if (!CreateProcessA(nullptr, cmdLine.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &info,
+        // tempFile is our own fully-resolved download path; pass it as an explicit
+        // application name so it is never subject to ambiguous PATH/CWD resolution.
+        if (!CreateProcessA(tempFile.string().c_str(), cmdLine.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &info,
                             &updateProcessInfo))
         {
             win32Error = GetLastError();

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -4,50 +4,7 @@
 #include "Util.h"
 #include "InstanceConfig.hpp"
 
-namespace
-{
-    /**
-     * \brief Quotes and escapes a single argument value for safe inclusion in a
-     * CreateProcess / ShellExecuteEx command string that will be parsed by
-     * CommandLineToArgvW.
-     *
-     * Algorithm: wrap in double-quotes, doubling any backslashes that immediately
-     * precede a double-quote or end the string, and escaping every embedded
-     * double-quote as \".
-     * See https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw
-     */
-    std::string QuoteArg(const std::string& arg)
-    {
-        std::string out;
-        out.reserve(arg.size() + 4);
-        out += '"';
-        size_t backslashes = 0;
-        for (const char c : arg)
-        {
-            if (c == '\\')
-            {
-                ++backslashes;
-            }
-            else if (c == '"')
-            {
-                // Double any preceding backslashes, then escape the quote.
-                out.append(backslashes * 2, '\\');
-                out += "\\\"";
-                backslashes = 0;
-            }
-            else
-            {
-                out.append(backslashes, '\\');
-                out += c;
-                backslashes = 0;
-            }
-        }
-        // Double trailing backslashes (they precede the closing quote).
-        out.append(backslashes * 2, '\\');
-        out += '"';
-        return out;
-    }
-}
+using winapi::QuoteArg;
 
 
 std::expected<void, std::string> models::InstanceConfig::ExtractSelfUpdater() const
@@ -106,17 +63,26 @@ std::expected<void, std::string> models::InstanceConfig::ExtractSelfUpdater() co
 
 bool models::InstanceConfig::HasWritePermissions() const
 {
-    const HANDLE self =
-      CreateFileA(appPath.string().c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    // Explicit, non-destructive probe: try to create-and-immediately-delete a uniquely
+    // named empty file in our own directory. This directly tests what actually matters
+    // (can we write new files there, e.g. the self-updater ADS and, post-swap, the main
+    // binary) instead of inferring it from a sharing violation on the running exe itself,
+    // which only proves the exe is locked, not that the directory is writable, and would
+    // report false for a perfectly writable, currently-unlocked location.
+    const std::string dir = appPath.parent_path().string();
 
-    const DWORD error = GetLastError();
+    char probePath[MAX_PATH]{};
+    if (GetTempFileNameA(dir.c_str(), "NVW", 0, probePath) == 0)
+    {
+        spdlog::debug("HasWritePermissions: GetTempFileNameA in '{}' failed, error {:#x}", dir, GetLastError());
+        return false;
+    }
 
-    if (self != INVALID_HANDLE_VALUE) CloseHandle(self);
+    // GetTempFileNameA(..., uUnique=0, ...) already created the (empty) file as a side
+    // effect of generating a unique name; remove it immediately so the probe leaves no trace.
+    DeleteFileA(probePath);
 
-    // error is ERROR_SHARING_VIOLATION when we can write
-    // and ERROR_ACCESS_DENIED if missing permissions
-
-    return error == ERROR_SHARING_VIOLATION;
+    return true;
 }
 
 std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
@@ -127,7 +93,16 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
     const auto ads = dllPath.str();
     spdlog::debug("ads = {}", ads);
 
-    const auto runDll = "rundll32.exe";
+    // Resolve rundll32.exe to its fully-qualified %SystemRoot%\System32 path and pass it
+    // as an explicit application name (lpApplicationName / SHELLEXECUTEINFO::lpFile) rather
+    // than letting CreateProcess/ShellExecuteEx resolve a bare "rundll32" through the
+    // default DLL/EXE search order (which can include the current directory).
+    const auto rundll32Path = winapi::GetSystemExecutablePath("rundll32.exe");
+    if (!rundll32Path)
+    {
+        return std::unexpected(std::format("Failed to resolve rundll32.exe: {}", rundll32Path.error()));
+    }
+    const auto& runDll = *rundll32Path;
 
     const auto& inst = remote.instance.value();
     const std::string latestUrl = inst.latestUrl.value();
@@ -184,7 +159,7 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
         si.wShowWindow = SW_HIDE;
 
         std::stringstream argsStream;
-        argsStream << "rundll32 \"" << ads << "\",PerformUpdate"
+        argsStream << QuoteArg(runDll) << " \"" << ads << "\",PerformUpdate"
                    << " --silent"
                    << " --log-level " << magic_enum::enum_name(spdlog::get_level())
                    << " --pid " << GetCurrentProcessId()
@@ -196,8 +171,15 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
         const auto args = argsStream.str();
         spdlog::debug("args = {}", args);
 
-        if (!CreateProcessA(nullptr,
-                            const_cast<LPSTR>(args.c_str()),
+        // lpApplicationName pins the executable to the resolved system path so it can
+        // never be resolved ambiguously via PATH/CWD search order; the command line's
+        // argv[0] is kept consistent with it for well-behaved child argument parsing.
+        // CreateProcessA may write into lpCommandLine while parsing/expanding arguments,
+        // so it must be a writable buffer, never a std::string's internal storage.
+        auto cmdLine = winapi::MakeWritableCommandLine(args);
+
+        if (!CreateProcessA(runDll.c_str(),
+                            cmdLine.data(),
                             nullptr,
                             nullptr,
                             TRUE,
@@ -243,7 +225,7 @@ std::expected<void, std::string> models::InstanceConfig::RunSelfUpdater() const
         shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
         shExInfo.hwnd = nullptr;
         shExInfo.lpVerb = "runas";
-        shExInfo.lpFile = runDll;
+        shExInfo.lpFile = runDll.c_str();
         shExInfo.lpParameters = args.c_str();
         shExInfo.lpDirectory = workDir.string().c_str();
         shExInfo.nShow = SW_HIDE;

--- a/src/InstanceConfig.Updater.cpp
+++ b/src/InstanceConfig.Updater.cpp
@@ -80,7 +80,13 @@ bool models::InstanceConfig::HasWritePermissions() const
 
     // GetTempFileNameA(..., uUnique=0, ...) already created the (empty) file as a side
     // effect of generating a unique name; remove it immediately so the probe leaves no trace.
-    DeleteFileA(probePath);
+    // Treat a failed delete as non-writable: create-without-delete would leave debris and
+    // is not a reliable signal that we can replace files here (e.g. delete-denied ACLs).
+    if (DeleteFileA(probePath) == FALSE)
+    {
+        spdlog::debug("HasWritePermissions: DeleteFileA('{}') failed, error {:#x}", probePath, GetLastError());
+        return false;
+    }
 
     return true;
 }

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -557,6 +557,15 @@ models::InstanceConfig::~InstanceConfig()
     RequestAbortDownload();
     WaitForDownloadToFinish();
 
+    // Backstop: ExecuteSetup() normally closes this handle itself right after its one
+    // use (TerminateProcess), but if setup never runs (e.g. no update was available, or
+    // the app exited first) it is still open and we own it, so close it here.
+    if (terminateProcessBeforeUpdate.has_value())
+    {
+        CloseHandle(terminateProcessBeforeUpdate.value());
+        terminateProcessBeforeUpdate.reset();
+    }
+
     // clean up release resources
     for (const auto& release : remote.releases)
     {

--- a/src/InstanceConfig.cpp
+++ b/src/InstanceConfig.cpp
@@ -561,6 +561,8 @@ models::InstanceConfig::~InstanceConfig()
     // never be destroyed while one is still running. The normal shutdown path (main.cpp)
     // already requests a stop and waits before destroying `cfg`, so these are typically
     // no-ops by the time we get here; they remain a backstop for any other exit path.
+    // WaitForVerifyToFinish requests stop on verifyStopSource before waiting so a long
+    // checksum hash can bail between chunks rather than pinning destruction.
     WaitForSetupToFinish();
     WaitForVerifyToFinish();
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -143,4 +143,37 @@ namespace winapi
      * \remarks The caller is responsible for calling DestroyIcon on the returned handle.
      */
     [[nodiscard]] std::expected<HICON, std::string> CreateIconFromIcoBuffer(const std::vector<uint8_t>& ico, int cx, int cy);
+
+    /**
+     * \brief Builds a writable, NUL-terminated command-line buffer suitable for
+     *        CreateProcessA's lpCommandLine parameter, which the API may modify in place
+     *        while parsing/expanding arguments.
+     * \param commandLine The command line to copy.
+     * \return A NUL-terminated buffer of commandLine.size()+1 bytes that CreateProcessA
+     *         may safely mutate; passing std::string::c_str()/data() there directly (even
+     *         via const_cast) is undefined behavior.
+     */
+    [[nodiscard]] std::vector<char> MakeWritableCommandLine(const std::string& commandLine);
+
+    /**
+     * \brief Resolves the fully-qualified path to a well-known executable inside
+     *        %SystemRoot%\System32 (e.g. "rundll32.exe"), for use as CreateProcess's/
+     *        ShellExecuteEx's explicit application name so the executable is never
+     *        resolved via an ambiguous PATH/CWD search order.
+     * \param exeName Base file name of the system executable, e.g. "rundll32.exe".
+     * \return The fully-qualified path on success; unexpected error string on failure.
+     */
+    [[nodiscard]] std::expected<std::string, std::string> GetSystemExecutablePath(const std::string& exeName);
+
+    /**
+     * \brief Quotes and escapes a single argument value for safe inclusion in a
+     * CreateProcess / ShellExecuteEx command string that will be parsed by
+     * CommandLineToArgvW-style rules.
+     *
+     * Algorithm: wrap in double-quotes, doubling any backslashes that immediately
+     * precede a double-quote or end the string, and escaping every embedded
+     * double-quote as \".
+     * See https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw
+     */
+    [[nodiscard]] std::string QuoteArg(const std::string& arg);
 }

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -72,7 +72,13 @@ namespace models
         std::vector<std::string> fallbackUpdateRequestUrls;
         /** Full pathname of the updater parent process file, if any */
         std::optional<std::filesystem::path> parentAppPath;
-        /** Process to terminate before update */
+        /**
+         * Process to terminate before update. This is a handle received from an external
+         * caller (--terminate-process-before-update), duplicated by them with
+         * bInheritHandle so we can act on it; we therefore own it and must close it.
+         * ExecuteSetup() closes it immediately after its one use (TerminateProcess);
+         * the destructor closes it as a backstop for any path where setup never runs.
+         */
         std::optional<HANDLE> terminateProcessBeforeUpdate;
 
         /** The local and remote shared configuration */

--- a/src/models/InstanceConfig.hpp
+++ b/src/models/InstanceConfig.hpp
@@ -92,6 +92,8 @@ namespace models
         std::optional<std::shared_future<std::expected<SetupResult, std::string>>> setupTask;
         /** The integrity-verification task */
         std::optional<std::shared_future<std::expected<void, std::string>>> verifyTask;
+        /** Cooperative cancel for verifyTask; fresh source per VerifyReleaseIntegrityAsync launch */
+        std::optional<std::stop_source> verifyStopSource;
         /** The selected release numeric ID */
         int selectedRelease{0};
         /** Human-readable download failure reason from last attempt (if any) */
@@ -634,15 +636,17 @@ namespace models
 
         /**
          * \brief Verifies the downloaded setup file integrity (checksum + Authenticode publisher pin).
-         * \return Empty on success; unexpected error string on failure.
+         * \param stopToken Cooperative cancel observed between hash chunks (and before Authenticode).
+         *                  Default (empty) token never stops — used by the synchronous silent-update path.
+         * \return Empty on success; unexpected error string on failure or cancellation.
          * \remarks Called between DownloadSucceeded and PrepareInstall in the UI state machine.
          *          Checksum: if present in the release it MUST match; absent = allowed in Relaxed, rejected in strict mode.
          *          Signature: governed by merged.signatureVerificationMode (WhenPresent / Required).
          */
-        [[nodiscard]] std::expected<void, std::string> VerifyReleaseIntegrity();
+        [[nodiscard]] std::expected<void, std::string> VerifyReleaseIntegrity(std::stop_token stopToken = {});
 
         /**
-         * \brief Launches VerifyReleaseIntegrity on a background thread.
+         * \brief Launches VerifyReleaseIntegrity on a background thread with a fresh stop_source.
          * \return Empty on success; unexpected error string if one is already running or
          *         if the system cannot start the background thread (std::system_error).
          */
@@ -671,7 +675,9 @@ namespace models
         void ResetVerifyState();
 
         /**
-         * \brief Blocks until the running verification task (if any) finishes.
+         * \brief Requests stop on the verify task's stop_source (if any), then blocks until it finishes.
+         * \remarks Mirrors the download abort-then-wait pattern so shutdown never destroys
+         *          InstanceConfig while hashing/Authenticode is still touching `this`.
          */
         void WaitForVerifyToFinish();
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -62,6 +62,7 @@
 #include <locale>
 #include <regex>
 #include <future>
+#include <stop_token>
 #include <optional>
 #include <string>
 #include <vector>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -834,4 +834,57 @@ namespace winapi
 
         return hIcon;
     }
+
+    std::vector<char> MakeWritableCommandLine(const std::string& commandLine)
+    {
+        std::vector<char> buffer(commandLine.begin(), commandLine.end());
+        buffer.push_back('\0');
+        return buffer;
+    }
+
+    std::expected<std::string, std::string> GetSystemExecutablePath(const std::string& exeName)
+    {
+        char systemDir[MAX_PATH]{};
+        const UINT len = GetSystemDirectoryA(systemDir, static_cast<UINT>(std::size(systemDir)));
+        if (len == 0 || len >= static_cast<UINT>(std::size(systemDir)))
+        {
+            return std::unexpected(GetLastErrorStdStr());
+        }
+
+        std::filesystem::path path(systemDir);
+        path /= exeName;
+        return path.string();
+    }
+
+    std::string QuoteArg(const std::string& arg)
+    {
+        std::string out;
+        out.reserve(arg.size() + 4);
+        out += '"';
+        size_t backslashes = 0;
+        for (const char c : arg)
+        {
+            if (c == '\\')
+            {
+                ++backslashes;
+            }
+            else if (c == '"')
+            {
+                // Double any preceding backslashes, then escape the quote.
+                out.append(backslashes * 2, '\\');
+                out += "\\\"";
+                backslashes = 0;
+            }
+            else
+            {
+                out.append(backslashes, '\\');
+                out += c;
+                backslashes = 0;
+            }
+        }
+        // Double trailing backslashes (they precede the closing quote).
+        out.append(backslashes * 2, '\\');
+        out += '"';
+        return out;
+    }
 }

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -807,6 +807,35 @@ try {
     # NV_S_INSTANCE_ALREADY_RUNNING (210) after signaling the owner.
     $results.Add((Invoke-DuplicateInstanceScenario -SourceBin $MainBin))
 
+    # ── Win32 process-launch argument round trip ─────────────────────────────
+    # The manifest's launchArguments for ProcessArgsRoundTrip is a raw command-line
+    # fragment with a quoted space, an embedded escaped quote, and a trailing escaped
+    # backslash (see E2EProcessArgsRoundTripEndpoint). ExecuteSetup appends it verbatim
+    # after the quoted setup.exe path and launches it via a writable CreateProcessA
+    # command-line buffer with an explicit lpApplicationName. The setup stub echoes its
+    # received argv (post CreateProcess-splitting) to E2E_ARGS_LOG_FILE, which the
+    # updater process propagates to it by simple environment inheritance. Regression
+    # coverage for the const_cast<LPSTR> removal / quoting changes in
+    # src/InstanceConfig.Setup.cpp: a broken writable buffer or bad quoting would
+    # corrupt or drop these tokens even though the exit code alone would still be 0/203.
+    $processArgsLogFile = Join-Path $LogDir 'ProcessArgsRoundTrip.args.log'
+    Remove-Item -Path $processArgsLogFile -ErrorAction SilentlyContinue
+
+    $processArgsResult = Invoke-Scenario -Name 'ProcessArgsRoundTrip' `
+        -SourceBin $MainBin -ExeName 'e2e_ProcessArgsRoundTrip_Updater.exe' `
+        -LocalVersion '0.0.1' -ExpectedExit 203 -SkipSelfUpdate $true `
+        -PreScenario  { $env:E2E_ARGS_LOG_FILE = $processArgsLogFile } `
+        -PostScenario { Remove-Item Env:\E2E_ARGS_LOG_FILE -ErrorAction SilentlyContinue }
+
+    $expectedArgs = @('arg with spaces', 'quote"inside', 'trailingback\')
+    $actualArgs   = if (Test-Path $processArgsLogFile) { @(Get-Content $processArgsLogFile) } else { @() }
+    if (@(Compare-Object $expectedArgs $actualArgs -SyncWindow 0).Count -ne 0) {
+        $processArgsResult.Passed = $false
+        $processArgsResult.LogFailures += "argv round-trip mismatch: expected [$($expectedArgs -join '|')], got [$($actualArgs -join '|')]"
+        Write-Host "  FAIL  ProcessArgsRoundTrip argv mismatch: expected [$($expectedArgs -join '|')], got [$($actualArgs -join '|')]"
+    }
+    $results.Add($processArgsResult)
+
 } finally {
     Stop-E2EServer $serverJob
 


### PR DESCRIPTION
## Summary

PR 4 of the runtime remediation plan: Win32 process and handle safety.

- Replaced the remaining `const_cast<LPSTR>(string.c_str())` `CreateProcessA` command
  lines (`dll/dll.cpp`'s post-swap main-process relaunch, `src/InstanceConfig.Updater.cpp`'s
  non-elevated self-updater DLL launch) with writable buffers, since `CreateProcessA` may
  mutate `lpCommandLine` in place while parsing/expanding arguments — passing a
  `std::string`'s internal storage there (even via `const_cast`) is undefined behavior.
- Pinned `lpApplicationName` / `SHELLEXECUTEINFO::lpFile` to an explicit, fully-resolved
  path everywhere a process is launched from this codebase (`rundll32.exe` resolved via
  `GetSystemDirectoryA`, or the already-resolved updater/main exe) instead of letting
  `CreateProcess`/`ShellExecuteEx` search for a bare name via an ambiguous PATH/CWD order.
- Applied the same writable-buffer + explicit-application-name treatment to the plain-EXE
  launch in `ExecuteSetup` (`src/InstanceConfig.Setup.cpp`), and promoted the existing
  `QuoteArg` helper to `winapi::QuoteArg` (`src/Util.h`/`.cpp`) so all three call sites in
  `src/` quote consistently; `dll/dll.cpp` keeps a small local copy since it's a separate
  compilation unit that doesn't link against `src/` (matching the existing pattern for its
  other duplicated helpers).
- Replaced `InstanceConfig::HasWritePermissions`'s sharing-violation inference — which only
  proved the *running exe* was locked, not that the *install directory* was writable, and
  would report `false` for a perfectly writable, currently-unlocked location — with an
  explicit, non-destructive `GetTempFileNameA`/`DeleteFileA` probe of that directory.
- Closed the `terminateProcessBeforeUpdate` handle right after its one use in
  `ExecuteSetup` (previously never closed, a handle leak), with a destructor backstop for
  any path where setup never runs.
- Documented `launchArguments` as an intentionally-preserved raw Windows command-line
  fragment (manifest-supplied, not re-parsed or re-quoted) so future changes don't
  accidentally "fix" it into a versioned-contract break.

## Test plan

- [x] x64 Release solution build (clean rebuild, 0 errors) via MSBuild.
- [x] Added `ProcessArgsRoundTrip` E2E scenario
      (`examples/server/Endpoints/E2E/E2EProcessArgsRoundTripEndpoint.cs`,
      `tests/e2e/run-e2e.ps1`): a manifest `launchArguments` fragment with a quoted
      space, an embedded escaped quote, and an escaped trailing backslash is launched via
      `ExecuteSetup`'s `CreateProcessA` call, and the setup stub
      (`examples/e2e-setup-stub/Program.cs`) echoes its received `argv` back to a file
      (`E2E_ARGS_LOG_FILE`, inherited like the existing `E2E_EXIT_DELAY_MS`/`E2E_EXIT_CODE`
      vars) for the harness to assert byte-exact round-trip.
- [x] Ran the full local E2E suite (25 scenarios passed, 2 skipped — dynamic-signing
      scenarios that need an optional minisign key not configured locally), including
      `SelfUpdate` (exercises the rewritten `HasWritePermissions`/`RunSelfUpdater`) and the
      new `ProcessArgsRoundTrip` scenario, confirmed argv arrived as exactly
      `["arg with spaces", "quote\"inside", "trailingback\\"]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update/setup process launching to correctly handle executable paths and arguments containing spaces, embedded quotes, and trailing/escaped backslashes.
  * Improved reliability around terminating pre-update processes and ensuring process handles are always cleaned up.
  * Enhanced release integrity verification to support cooperative cancellation, improving responsiveness and safety during long-running checks.
* **Tests**
  * Added end-to-end coverage to verify round-tripped command-line arguments (including spaces, embedded quotes, and escaped trailing backslashes) during update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->