### PR TITLE
Enforce verification-policy trust boundary on remote manifests

### DIFF
--- a/abstractions/src/Models/SharedConfig.cs
+++ b/abstractions/src/Models/SharedConfig.cs
@@ -77,21 +77,35 @@ public sealed class SharedConfig
     /// <summary>
     ///     Global Authenticode verification mode for downloaded setups.
     /// </summary>
+    /// <remarks>
+    ///     <b>Trust boundary:</b> the client only honors this remote override when the manifest
+    ///     itself was verified against a compiled-in <c>NV_MANIFEST_PUBLIC_KEY</c> (i.e. the
+    ///     client build supports manifest signing and the response's Ed25519/minisign signature
+    ///     checked out). On a client build without a compiled-in public key — the common case
+    ///     when the server does not sign its manifests — this field is silently ignored and the
+    ///     client's local/default value is kept, because an unauthenticated response must never
+    ///     be able to change how strictly downloaded binaries are verified. Set this locally
+    ///     (compiled default, or <c>--strict-verification</c>) instead if manifest signing is not
+    ///     in use.
+    /// </remarks>
     public SignatureVerificationMode? SignatureVerificationMode { get; set; }
 
     /// <summary>
     ///     Global Authenticode comparison policy.
     /// </summary>
+    /// <remarks>See the trust-boundary remarks on <see cref="SignatureVerificationMode" />; the same rule applies here.</remarks>
     public SignatureComparisonPolicy? SignaturePolicy { get; set; }
 
     /// <summary>
     ///     Global Authenticode pin strategy.
     /// </summary>
+    /// <remarks>See the trust-boundary remarks on <see cref="SignatureVerificationMode" />; the same rule applies here.</remarks>
     public SignatureVerificationStrategy? SignatureStrategy { get; set; }
 
     /// <summary>
     ///     Explicit certificate pin (used with <see cref="SignatureVerificationStrategy.FromConfiguration" />).
     /// </summary>
+    /// <remarks>See the trust-boundary remarks on <see cref="SignatureVerificationMode" />; the same rule applies here.</remarks>
     public SignatureConfig? SignatureConfig { get; set; }
 
     /// <summary>

--- a/examples/server/Endpoints/DefaultDemoEndpoint.cs
+++ b/examples/server/Endpoints/DefaultDemoEndpoint.cs
@@ -94,6 +94,16 @@ internal sealed class DefaultDemoEndpoint : EndpointWithoutRequest
                 // actual values on the .NET Desktop Runtime installer cert (confirmed from logs).
                 // SubjectName is stable across renewals; IssuerName is semi-stable but provides
                 // an extra layer to demonstrate multi-field pinning in the demo.
+                //
+                // NOTE: as of the verification-policy trust-boundary hardening, the client only
+                // honors this remote override when the manifest itself passed Ed25519/minisign
+                // verification against a compiled-in NV_MANIFEST_PUBLIC_KEY (see the SignedManifest
+                // E2E scenario / tests/e2e/include/sig). This demo server does not sign its
+                // manifests, so on a plain client build (no compiled-in public key, e.g.
+                // example_Demo_Updater) this override is logged and ignored, and the client keeps
+                // its local/default signature policy instead. To actually enforce a remote
+                // signature policy like this one, either sign your manifests, or set the policy
+                // locally on the client (compiled default or --strict-verification).
                 SignatureVerificationMode = SignatureVerificationMode.Required,
                 SignaturePolicy = SignatureComparisonPolicy.Strict,
                 SignatureConfig = new SignatureConfig

--- a/examples/server/Endpoints/E2E/E2EUnsignedOverrideRejectedEndpoint.cs
+++ b/examples/server/Endpoints/E2E/E2EUnsignedOverrideRejectedEndpoint.cs
@@ -1,0 +1,90 @@
+using FastEndpoints;
+
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Nefarius.Vicius.Example.Server.Endpoints.E2E;
+
+/// <summary>
+///     E2E scenario: update available, ZIP payload, correct SHA-256 checksum, but the manifest
+///     is served <b>unsigned</b> (no <c>.minisig</c> sidecar / requires no compiled-in
+///     <c>NV_MANIFEST_PUBLIC_KEY</c>) while attempting to weaken all four Authenticode
+///     verification-policy fields (<c>SignatureVerificationMode</c>, <c>SignaturePolicy</c>,
+///     <c>SignatureStrategy</c>, <c>SignatureConfig</c>).
+///     <para>
+///         Regression coverage for the verification-policy trust boundary in
+///         <c>InstanceConfig::RequestUpdateInfo</c> (src/InstanceConfig.Web.cpp): an
+///         unverifiable manifest must never be able to change these fields. The update must
+///         still succeed (the local default <c>WhenPresent</c> mode already accepts the
+///         unsigned test payload), but the log must show every override being rejected — see
+///         the <c>UnsignedOverrideRejected</c> scenario in tests/e2e/run-e2e.ps1, which asserts
+///         on the "Ignoring remote ... override" warning lines.
+///     </para>
+///     Expected updater exit code: <c>NV_S_UPDATE_FINISHED = 203</c>.
+///     Only active when <c>VICIUS_E2E=1</c>.
+/// </summary>
+internal sealed class E2EUnsignedOverrideRejectedEndpoint : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get("api/e2e/UnsignedOverrideRejected/updates.json");
+        AllowAnonymous();
+        Options(x => x.WithTags("E2E"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        if (!E2EGuard.IsEnabled)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        string artifactsDir = E2EGuard.ArtifactsDir;
+        if (string.IsNullOrEmpty(artifactsDir))
+            ThrowError("E2E_ARTIFACTS_DIR is not set", 500);
+
+        string zipPath = Path.Combine(artifactsDir, "payload.zip");
+        if (!File.Exists(zipPath))
+            ThrowError("E2E fixture 'payload.zip' not found in artifacts directory", 500);
+
+        string checksum = E2EGuard.ComputeSha256(zipPath);
+        string baseUrl = E2EGuard.BaseUrl(HttpContext);
+
+        UpdateResponse response = new()
+        {
+            Shared = new SharedConfig
+            {
+                ProductName = "E2E Test Product",
+                WindowTitle = "E2E UnsignedOverrideRejected Updater",
+                // Attempted weakening: this manifest is served unsigned (this endpoint's
+                // route has no NV_MANIFEST_PUBLIC_KEY / .minisig involved at all), so the
+                // client must ignore all four of these and keep its local/default policy.
+                SignatureVerificationMode = SignatureVerificationMode.Disabled,
+                SignaturePolicy = SignatureComparisonPolicy.Relaxed,
+                SignatureStrategy = SignatureVerificationStrategy.FromConfiguration,
+                SignatureConfig = new SignatureConfig
+                {
+                    SubjectName = "Attacker-Controlled CN"
+                }
+            },
+            Releases =
+            {
+                new UpdateRelease
+                {
+                    Name = "E2E Unsigned Override Rejected Update v2.0.0",
+                    Version = System.Version.Parse("2.0.0"),
+                    PublishedAt = DateTimeOffset.UtcNow,
+                    Summary = string.Empty,
+                    DownloadUrl = $"{baseUrl}/api/e2e/artifacts/payload.zip",
+                    Checksum = new ChecksumParameters
+                    {
+                        ChecksumAlg = ChecksumAlgorithm.SHA256,
+                        Checksum = checksum
+                    }
+                }
+            }
+        };
+
+        await Send.OkAsync(response, ct);
+    }
+}

--- a/src/InstanceConfig.Web.cpp
+++ b/src/InstanceConfig.Web.cpp
@@ -1021,6 +1021,14 @@ namespace
                 // Layer 3: Manifest signature verification (Ed25519 / minisign)
                 // Must happen BEFORE json::parse so a tampered body is never trusted.
                 //
+                // Gates the remote security-policy override merge below (see
+                // "Trust boundary" comment further down): only a manifest that has
+                // actually passed this check may weaken/change local signature
+                // verification settings. Builds without NV_MANIFEST_PUBLIC_KEY have no
+                // way to verify a manifest at all, so this stays false unconditionally
+                // for them, which is exactly the "unsigned remote can never weaken
+                // local policy" behavior we want.
+                bool manifestSignatureVerified = false;
 #if defined(NV_MANIFEST_PUBLIC_KEY)
                 {
                     // Derive the .minisig sidecar URL by appending ".minisig" to the manifest URL
@@ -1066,6 +1074,7 @@ namespace
                     }
 
                     spdlog::info("Manifest signature verified successfully");
+                    manifestSignatureVerified = true;
                 }
 #endif
 
@@ -1184,18 +1193,57 @@ namespace
 
                     if (shared.runAsTemporaryCopy.has_value()) merged.runAsTemporaryCopy = shared.runAsTemporaryCopy.value();
 
-                    // Signature verification settings from server (do not override strict mode set by CLI)
-                    if (shared.signatureVerificationMode.has_value() && !strictVerification)
-                        merged.signatureVerificationMode = shared.signatureVerificationMode.value();
+                    // ── Trust boundary: signature verification settings from the server ──
+                    // These four fields gate whether a downloaded release binary's
+                    // Authenticode signature is checked at all (signatureVerificationMode),
+                    // how strictly (signaturePolicy), and against which identity
+                    // (signatureStrategy / signatureConfig — the certificate pin). Letting
+                    // an unverifiable manifest change them would let anyone who can answer
+                    // the manifest URL (a compromised/MITM'd server, or a captive portal)
+                    // silently turn off release-binary verification for a build that has no
+                    // way to check the manifest itself. So a remote override is only ever
+                    // honored when manifestSignatureVerified is true, i.e. the manifest
+                    // itself passed Ed25519/minisign verification against the compiled-in
+                    // NV_MANIFEST_PUBLIC_KEY above; builds without that key can never
+                    // satisfy this and always keep the local/default policy. A local
+                    // --strict-verification flag remains dominant either way.
+                    const bool allowSignaturePolicyOverride = manifestSignatureVerified && !strictVerification;
 
-                    if (shared.signaturePolicy.has_value() && !strictVerification)
-                        merged.signaturePolicy = shared.signaturePolicy.value();
+                    if (shared.signatureVerificationMode.has_value())
+                    {
+                        if (allowSignaturePolicyOverride)
+                            merged.signatureVerificationMode = shared.signatureVerificationMode.value();
+                        else
+                            spdlog::warn("Ignoring remote signatureVerificationMode override: manifest was not "
+                                         "verified against a compiled-in public key, or --strict-verification is active");
+                    }
 
-                    if (shared.signatureStrategy.has_value() && !strictVerification)
-                        merged.signatureStrategy = shared.signatureStrategy.value();
+                    if (shared.signaturePolicy.has_value())
+                    {
+                        if (allowSignaturePolicyOverride)
+                            merged.signaturePolicy = shared.signaturePolicy.value();
+                        else
+                            spdlog::warn("Ignoring remote signaturePolicy override: manifest was not verified "
+                                         "against a compiled-in public key, or --strict-verification is active");
+                    }
 
-                    if (shared.signatureConfig.has_value() && !strictVerification)
-                        merged.signatureConfig = shared.signatureConfig.value();
+                    if (shared.signatureStrategy.has_value())
+                    {
+                        if (allowSignaturePolicyOverride)
+                            merged.signatureStrategy = shared.signatureStrategy.value();
+                        else
+                            spdlog::warn("Ignoring remote signatureStrategy override: manifest was not verified "
+                                         "against a compiled-in public key, or --strict-verification is active");
+                    }
+
+                    if (shared.signatureConfig.has_value())
+                    {
+                        if (allowSignaturePolicyOverride)
+                            merged.signatureConfig = shared.signatureConfig.value();
+                        else
+                            spdlog::warn("Ignoring remote signatureConfig (certificate pin) override: manifest was "
+                                         "not verified against a compiled-in public key, or --strict-verification is active");
+                    }
 
                     if (shared.hideRemindButton.has_value()) merged.hideRemindButton = shared.hideRemindButton.value();
 

--- a/src/models/SharedConfig.hpp
+++ b/src/models/SharedConfig.hpp
@@ -30,7 +30,16 @@ namespace models
         std::optional<DownloadLocationConfig> downloadLocation;
         /** True to run as temporary copy */
         std::optional<bool> runAsTemporaryCopy;
-        /** Global Authenticode verification mode (default: WhenPresent) */
+        /**
+         * Global Authenticode verification mode (default: WhenPresent), signaturePolicy,
+         * signatureStrategy and signatureConfig below are all subject to the same trust
+         * boundary: InstanceConfig::RequestUpdateInfo() (src/InstanceConfig.Web.cpp) only
+         * applies a remote override for these four fields when the manifest itself passed
+         * Ed25519/minisign verification against a compiled-in NV_MANIFEST_PUBLIC_KEY.
+         * Builds without that key can never satisfy this, so an unsigned manifest can never
+         * weaken (or change) local signature-verification policy; --strict-verification
+         * remains dominant either way.
+         */
         std::optional<SignatureVerificationMode> signatureVerificationMode;
         /** Global Authenticode comparison policy (default: Relaxed) */
         std::optional<SignatureComparisonPolicy> signaturePolicy;

--- a/tests/e2e/run-e2e.ps1
+++ b/tests/e2e/run-e2e.ps1
@@ -151,7 +151,8 @@ function Invoke-Scenario {
         [scriptblock] $PreScenario        = $null,    # runs before the binary is invoked
         [scriptblock] $PostScenario       = $null,   # runs in finally, even on failure
         [string[]]    $ExpectLogContains    = @(),   # each substring must appear in the log file
-        [string[]]    $ExpectLogNotContains = @()    # none of these substrings may appear in the log file
+        [string[]]    $ExpectLogNotContains = @(),   # none of these substrings may appear in the log file
+        [string[]]    $ExtraArgs            = @()    # additional CLI args appended verbatim (e.g. --strict-verification)
     )
 
     Write-Header "Scenario: $Name (expect exit $ExpectedExit)"
@@ -206,6 +207,7 @@ function Invoke-Scenario {
             $args = @('--force-local-version', $LocalVersion) + $args
         }
         if ($SkipSelfUpdate) { $args += '--skip-self-update' }
+        if ($ExtraArgs.Count -gt 0) { $args += $ExtraArgs }
 
         Write-Host "  Running: $ExeName $args"
         $proc = Start-Process `
@@ -560,12 +562,20 @@ try {
             NeedsInstall   = $true
         },
         @{
-            Name           = 'SignedManifest'
-            SourceBin      = $SigBin
-            ExeName        = 'e2eSig_SignedManifest_Updater.exe'
-            LocalVersion   = '0.0.1'
-            ExpectedExit   = 203
-            SkipSelfUpdate = $true
+            # SignedManifest's fixture (tests/e2e's SignedManifest/updates.json) sets
+            # shared.signatureVerificationMode = "Disabled" and is served with a valid
+            # minisig signature against $SigBin's compiled-in NV_MANIFEST_PUBLIC_KEY, so the
+            # override must be applied (not rejected) — proving a verified manifest CAN apply
+            # an allowed policy override. Absence of the "Ignoring remote ... override" log
+            # lines (added by the verification-policy trust-boundary hardening) is the
+            # positive-control signal for this.
+            Name              = 'SignedManifest'
+            SourceBin         = $SigBin
+            ExeName           = 'e2eSig_SignedManifest_Updater.exe'
+            LocalVersion      = '0.0.1'
+            ExpectedExit      = 203
+            SkipSelfUpdate    = $true
+            ExpectLogNotContains = @('Ignoring remote signatureVerificationMode override')
         },
         @{
             Name           = 'TamperedManifest'
@@ -574,6 +584,47 @@ try {
             LocalVersion   = '0.0.1'
             ExpectedExit   = 104
             SkipSelfUpdate = $true
+        },
+        @{
+            # Negative control for SignedManifest: same signed manifest/override, but
+            # --strict-verification is passed locally on the CLI. A local operator flag must
+            # remain dominant over even a *verified* remote override: the override is
+            # rejected (log line present) even though the manifest signature itself is valid,
+            # AND --strict-verification additionally escalates the local default policy from
+            # WhenPresent/Relaxed to Required/Strict (see InstanceConfig::InstanceConfig).
+            # Since the test payload.zip is unsigned, Required mode then hard-fails it with
+            # NV_E_SIGNATURE_INVALID (116) instead of the 203 every other happy-path scenario
+            # gets — the strongest possible proof that the remote "Disabled" override never
+            # took effect. Reuses the SignedManifest fixture/endpoint (same tenant path via
+            # ExeName) so the manifest and its signature are identical to that scenario —
+            # only the local --strict-verification flag differs.
+            Name                 = 'StrictVerificationDominant'
+            SourceBin            = $SigBin
+            ExeName              = 'e2eSig_SignedManifest_Updater.exe'
+            LocalVersion         = '0.0.1'
+            ExpectedExit         = 116
+            SkipSelfUpdate       = $true
+            ExtraArgs            = @('--strict-verification')
+            ExpectLogContains    = @('Ignoring remote signatureVerificationMode override')
+        },
+        @{
+            # Unsigned manifest (no NV_MANIFEST_PUBLIC_KEY / .minisig involved, served over
+            # $MainBin's plain HTTP loopback) attempts to weaken all four signature-policy
+            # fields. The update still succeeds (local default WhenPresent already accepts
+            # the unsigned test payload) but every override must be logged as rejected,
+            # proving an unsigned manifest cannot disable verification.
+            Name              = 'UnsignedOverrideRejected'
+            SourceBin         = $MainBin
+            ExeName           = 'e2e_UnsignedOverrideRejected_Updater.exe'
+            LocalVersion      = '0.0.1'
+            ExpectedExit      = 203
+            SkipSelfUpdate    = $true
+            ExpectLogContains = @(
+                'Ignoring remote signatureVerificationMode override',
+                'Ignoring remote signaturePolicy override',
+                'Ignoring remote signatureStrategy override',
+                'Ignoring remote signatureConfig (certificate pin) override'
+            )
         },
 
         # ── Dynamic server-side signing (minisign-net) scenarios ─────────────
@@ -799,6 +850,7 @@ try {
             PostScenario         = $s.ContainsKey('PostScenario')         ? $s.PostScenario         : $null
             ExpectLogContains    = $s.ContainsKey('ExpectLogContains')    ? $s.ExpectLogContains    : @()
             ExpectLogNotContains = $s.ContainsKey('ExpectLogNotContains') ? $s.ExpectLogNotContains : @()
+            ExtraArgs            = $s.ContainsKey('ExtraArgs')            ? $s.ExtraArgs            : @()
         }
         $results.Add((Invoke-Scenario @invokeParams))
     }


### PR DESCRIPTION
## Summary

PR 5 (final) of the runtime remediation plan: verification-policy trust boundary.

- `InstanceConfig::RequestUpdateInfo` (`src/InstanceConfig.Web.cpp`) previously applied a
  remote manifest's `signatureVerificationMode` / `signaturePolicy` / `signatureStrategy` /
  `signatureConfig` (certificate pin) overrides to any HTTP-200 response, gated only by the
  local `--strict-verification` flag. On a client build without a compiled-in
  `NV_MANIFEST_PUBLIC_KEY` — the common case, since manifest signing is opt-in — this let a
  compromised or MITM'd server silently disable Authenticode verification of downloaded
  release binaries.
- These four fields are now only overridden once the manifest itself has passed
  Ed25519/minisign verification against the compiled-in public key; otherwise the
  local/default policy is kept and the rejected override is logged
  (`Ignoring remote <field> override: ...`). `--strict-verification` remains dominant either
  way (and still escalates the local default to `Required`/`Strict`, unchanged from before).
- Documented the new trust boundary on the affected `SharedConfig` fields in both the C++
  model (`src/models/SharedConfig.hpp`) and the public C# abstractions
  (`abstractions/src/Models/SharedConfig.cs`, source of the generated API docs).
- Updated `DefaultDemoEndpoint`'s example comment to explain its remote strict-verification
  demo now requires a signed manifest to take effect on a plain (unsigned) build — this is an
  intentional compatibility change for any deployment relying on an *unsigned* manifest to
  remotely strengthen (or weaken) signature policy; see the commit message for the full
  rationale.

## Test plan

- [x] x64 Release solution build (clean rebuild, 0 errors) via MSBuild.
- [x] Added three E2E regressions in `tests/e2e/run-e2e.ps1`:
  - `SignedManifest` (existing scenario) now also asserts the "Ignoring remote ... override"
    log line is **absent**, proving a manifest that passed signature verification can still
    apply its allowed override.
  - `StrictVerificationDominant`: same signed manifest/override plus a local
    `--strict-verification` flag — the override is still rejected (log line present) and
    local policy escalates to `Required`, hard-failing the unsigned test payload with
    `NV_E_SIGNATURE_INVALID` (116), proving the local flag dominates even a *validly signed*
    remote override.
  - `UnsignedOverrideRejected`: a new endpoint
    (`examples/server/Endpoints/E2E/E2EUnsignedOverrideRejectedEndpoint.cs`) serves an
    unsigned manifest attempting to weaken all four fields; the update still completes under
    local defaults (203) and the log shows all four overrides rejected.
- [x] Ran the full local E2E suite: 26 scenarios passed, 2 skipped (dynamic-signing scenarios
      that need an optional minisign key not configured locally), including `SignedManifest`,
      `TamperedManifest`, `StrictVerificationDominant`, and `UnsignedOverrideRejected`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Remote signature-policy overrides are now accepted only when the update manifest is verified against the built-in public key.
  - Unverified or unsigned manifests can no longer weaken local signature verification settings; attempted overrides are ignored and logged.
  - Strict verification settings continue to take precedence over remote configuration.

- **Testing**
  - Added coverage for signed, unsigned, and strict-verification update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->